### PR TITLE
feat: Navigation API Endpoints (Issue #7)

### DIFF
--- a/src/mcp_server/api/__init__.py
+++ b/src/mcp_server/api/__init__.py
@@ -1,0 +1,5 @@
+"""API module for MCP Documentation Server."""
+
+from mcp_server.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/mcp_server/api/app.py
+++ b/src/mcp_server/api/app.py
@@ -1,0 +1,38 @@
+"""FastAPI application factory.
+
+Creates and configures the FastAPI application with all routers.
+"""
+
+from fastapi import FastAPI
+
+from mcp_server import __version__
+from mcp_server.api import navigation
+from mcp_server.structure_index import StructureIndex
+
+
+def create_app(index: StructureIndex | None = None) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        index: Optional pre-configured StructureIndex.
+               If None, the index must be set later.
+
+    Returns:
+        Configured FastAPI application
+    """
+    app = FastAPI(
+        title="MCP Documentation Server",
+        description="LLM interaction with large documentation projects via MCP",
+        version=__version__,
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    # Set the index for the navigation router
+    if index is not None:
+        navigation.set_index(index)
+
+    # Include routers
+    app.include_router(navigation.router)
+
+    return app

--- a/src/mcp_server/api/models.py
+++ b/src/mcp_server/api/models.py
@@ -1,0 +1,74 @@
+"""Pydantic models for API responses.
+
+These models define the JSON response structure for the Navigation API
+as specified in 02_api_specification.adoc.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class LocationResponse(BaseModel):
+    """Location of a section in a source file."""
+
+    file: str = Field(description="Relative path to the file")
+    line: int = Field(description="1-based line number")
+
+
+class SectionResponse(BaseModel):
+    """Section response for structure endpoint."""
+
+    path: str = Field(description="Hierarchical path (e.g., '/chapter-1/section-2')")
+    title: str = Field(description="Section title")
+    level: int = Field(description="Nesting depth (1 = chapter)")
+    location: LocationResponse
+    children: list["SectionResponse"] = Field(default_factory=list)
+
+
+class StructureResponse(BaseModel):
+    """Response for GET /structure endpoint."""
+
+    sections: list[SectionResponse]
+    total_sections: int = Field(description="Total number of sections in index")
+
+
+class SectionDetailResponse(BaseModel):
+    """Detailed section response for GET /section/{path}."""
+
+    path: str
+    title: str
+    level: int
+    location: LocationResponse
+    format: str = Field(description="Document format: 'asciidoc' or 'markdown'")
+
+
+class SectionSummary(BaseModel):
+    """Summary of a section (without children)."""
+
+    path: str
+    title: str
+
+
+class SectionsAtLevelResponse(BaseModel):
+    """Response for GET /sections endpoint."""
+
+    level: int
+    sections: list[SectionSummary]
+    count: int
+
+
+class ErrorDetail(BaseModel):
+    """Error detail in error response."""
+
+    code: str = Field(description="Error code (e.g., 'PATH_NOT_FOUND')")
+    message: str = Field(description="Human-readable error message")
+    details: dict | None = Field(default=None, description="Additional details")
+
+
+class ErrorResponse(BaseModel):
+    """Standardized error response."""
+
+    error: ErrorDetail
+
+
+# Allow forward references
+SectionResponse.model_rebuild()

--- a/src/mcp_server/api/navigation.py
+++ b/src/mcp_server/api/navigation.py
@@ -1,0 +1,169 @@
+"""Navigation API router.
+
+Provides endpoints for navigating the document structure:
+- GET /structure - Get hierarchical document structure
+- GET /section/{path} - Get a specific section
+- GET /sections - Get sections at a specific level
+"""
+
+from fastapi import APIRouter, HTTPException, Path, Query
+
+from mcp_server.api.models import (
+    ErrorDetail,
+    ErrorResponse,
+    LocationResponse,
+    SectionDetailResponse,
+    SectionResponse,
+    SectionsAtLevelResponse,
+    SectionSummary,
+    StructureResponse,
+)
+from mcp_server.structure_index import StructureIndex
+
+router = APIRouter(prefix="/api/v1", tags=["Navigation"])
+
+# Global index reference - will be set by create_app
+_index: StructureIndex | None = None
+
+
+def set_index(index: StructureIndex) -> None:
+    """Set the global structure index."""
+    global _index
+    _index = index
+
+
+def get_index() -> StructureIndex:
+    """Get the global structure index."""
+    if _index is None:
+        raise HTTPException(
+            status_code=503,
+            detail=ErrorResponse(
+                error=ErrorDetail(
+                    code="INDEX_NOT_READY",
+                    message="Server index is not initialized",
+                )
+            ).model_dump(),
+        )
+    return _index
+
+
+@router.get(
+    "/structure",
+    response_model=StructureResponse,
+    summary="Get document structure",
+    description="Returns the hierarchical document structure.",
+)
+def get_structure(
+    max_depth: int | None = Query(
+        default=None,
+        description="Maximum depth of returned structure. None for unlimited.",
+        ge=1,
+    ),
+) -> StructureResponse:
+    """Get the hierarchical document structure."""
+    index = get_index()
+    structure = index.get_structure(max_depth=max_depth)
+
+    sections = [_section_dict_to_response(s) for s in structure["sections"]]
+
+    return StructureResponse(
+        sections=sections,
+        total_sections=structure["total_sections"],
+    )
+
+
+@router.get(
+    "/section/{path:path}",
+    response_model=SectionDetailResponse,
+    responses={
+        404: {"model": ErrorResponse, "description": "Section not found"},
+    },
+    summary="Get section by path",
+    description="Returns a specific section by its hierarchical path.",
+)
+def get_section(
+    path: str = Path(description="Hierarchical path to the section"),
+) -> SectionDetailResponse:
+    """Get a specific section by path."""
+    index = get_index()
+
+    # Normalize path - ensure it starts with /
+    normalized_path = f"/{path}" if not path.startswith("/") else path
+
+    section = index.get_section(normalized_path)
+
+    if section is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": {
+                    "code": "PATH_NOT_FOUND",
+                    "message": f"Section '{normalized_path}' not found",
+                    "details": {
+                        "requested_path": normalized_path,
+                    },
+                }
+            },
+        )
+
+    # Determine format from file extension
+    file_path = str(section.source_location.file)
+    if file_path.endswith(".md"):
+        format_type = "markdown"
+    else:
+        format_type = "asciidoc"
+
+    return SectionDetailResponse(
+        path=section.path,
+        title=section.title,
+        level=section.level,
+        location=LocationResponse(
+            file=file_path,
+            line=section.source_location.line,
+        ),
+        format=format_type,
+    )
+
+
+@router.get(
+    "/sections",
+    response_model=SectionsAtLevelResponse,
+    summary="Get sections at level",
+    description="Returns all sections at a specific nesting level.",
+)
+def get_sections(
+    level: int = Query(
+        description="Nesting level (1 = chapter, 2 = section, etc.)",
+        ge=1,
+    ),
+) -> SectionsAtLevelResponse:
+    """Get all sections at a specific level."""
+    index = get_index()
+
+    sections = index.get_sections_at_level(level)
+
+    section_summaries = [
+        SectionSummary(path=s.path, title=s.title) for s in sections
+    ]
+
+    return SectionsAtLevelResponse(
+        level=level,
+        sections=section_summaries,
+        count=len(section_summaries),
+    )
+
+
+def _section_dict_to_response(section_dict: dict) -> SectionResponse:
+    """Convert a section dictionary from index to response model."""
+    children = [_section_dict_to_response(c) for c in section_dict.get("children", [])]
+
+    return SectionResponse(
+        path=section_dict["path"],
+        title=section_dict["title"],
+        level=section_dict["level"],
+        location=LocationResponse(
+            file=section_dict["location"]["file"],
+            line=section_dict["location"]["line"],
+        ),
+        children=children,
+    )

--- a/tests/test_navigation_api.py
+++ b/tests/test_navigation_api.py
@@ -1,0 +1,288 @@
+"""Tests for Navigation API endpoints.
+
+These tests verify the Navigation API endpoints:
+- GET /api/v1/structure
+- GET /api/v1/section/{path}
+- GET /api/v1/sections
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_server.api.app import create_app
+from mcp_server.models import Document, Element, Section, SourceLocation
+from mcp_server.structure_index import StructureIndex
+
+
+@pytest.fixture
+def sample_index() -> StructureIndex:
+    """Create a sample index with test data."""
+    index = StructureIndex()
+    doc = Document(
+        file_path=Path("docs/intro.adoc"),
+        title="Test Documentation",
+        sections=[
+            Section(
+                title="Introduction",
+                level=1,
+                path="/introduction",
+                source_location=SourceLocation(file=Path("docs/intro.adoc"), line=1),
+                children=[
+                    Section(
+                        title="Goals",
+                        level=2,
+                        path="/introduction/goals",
+                        source_location=SourceLocation(
+                            file=Path("docs/intro.adoc"), line=10
+                        ),
+                    ),
+                    Section(
+                        title="Scope",
+                        level=2,
+                        path="/introduction/scope",
+                        source_location=SourceLocation(
+                            file=Path("docs/intro.adoc"), line=20
+                        ),
+                    ),
+                ],
+            ),
+            Section(
+                title="Constraints",
+                level=1,
+                path="/constraints",
+                source_location=SourceLocation(file=Path("docs/constraints.adoc"), line=1),
+                children=[
+                    Section(
+                        title="Technical",
+                        level=2,
+                        path="/constraints/technical",
+                        source_location=SourceLocation(
+                            file=Path("docs/constraints.adoc"), line=15
+                        ),
+                    ),
+                ],
+            ),
+        ],
+        elements=[
+            Element(
+                type="code",
+                source_location=SourceLocation(file=Path("docs/intro.adoc"), line=25),
+                attributes={"language": "python"},
+                parent_section="/introduction/goals",
+            ),
+        ],
+    )
+    index.build_from_documents([doc])
+    return index
+
+
+@pytest.fixture
+def client(sample_index: StructureIndex) -> TestClient:
+    """Create a test client with the sample index."""
+    app = create_app(sample_index)
+    return TestClient(app)
+
+
+class TestGetStructure:
+    """Tests for GET /api/v1/structure endpoint."""
+
+    def test_get_structure_returns_200(self, client: TestClient):
+        """AC-NAV-01: GET /structure returns 200."""
+        response = client.get("/api/v1/structure")
+        assert response.status_code == 200
+
+    def test_get_structure_returns_all_sections(self, client: TestClient):
+        """AC-NAV-01: Response contains all sections."""
+        response = client.get("/api/v1/structure")
+        data = response.json()
+
+        assert "sections" in data
+        assert "total_sections" in data
+        assert data["total_sections"] == 5  # 2 level-1 + 3 level-2
+
+    def test_get_structure_is_hierarchical(self, client: TestClient):
+        """AC-NAV-01: Structure is hierarchically nested."""
+        response = client.get("/api/v1/structure")
+        data = response.json()
+
+        # Check top-level sections
+        assert len(data["sections"]) == 2
+        assert data["sections"][0]["path"] == "/introduction"
+        assert data["sections"][0]["title"] == "Introduction"
+
+        # Check nested children
+        intro = data["sections"][0]
+        assert "children" in intro
+        assert len(intro["children"]) == 2
+        assert intro["children"][0]["path"] == "/introduction/goals"
+
+    def test_get_structure_with_max_depth_1(self, client: TestClient):
+        """AC-NAV-02: max_depth=1 returns only level 1 sections."""
+        response = client.get("/api/v1/structure?max_depth=1")
+        data = response.json()
+
+        assert response.status_code == 200
+        assert len(data["sections"]) == 2
+
+        # Children should be empty due to max_depth
+        for section in data["sections"]:
+            assert section["children"] == []
+
+    def test_get_structure_with_max_depth_2(self, client: TestClient):
+        """max_depth=2 returns levels 1 and 2."""
+        response = client.get("/api/v1/structure?max_depth=2")
+        data = response.json()
+
+        assert response.status_code == 200
+
+        # Level 1 sections should have children
+        intro = data["sections"][0]
+        assert len(intro["children"]) == 2
+
+        # Level 2 children should have empty children (no level 3)
+        for child in intro["children"]:
+            assert child["children"] == []
+
+    def test_get_structure_section_has_location(self, client: TestClient):
+        """Sections include location information."""
+        response = client.get("/api/v1/structure")
+        data = response.json()
+
+        section = data["sections"][0]
+        assert "location" in section
+        assert "file" in section["location"]
+        assert "line" in section["location"]
+
+
+class TestGetSection:
+    """Tests for GET /api/v1/section/{path} endpoint."""
+
+    def test_get_section_returns_200(self, client: TestClient):
+        """AC-NAV-03: GET /section/{path} returns 200 for existing section."""
+        response = client.get("/api/v1/section/introduction")
+        assert response.status_code == 200
+
+    def test_get_section_returns_section_data(self, client: TestClient):
+        """AC-NAV-03: Response contains section data."""
+        response = client.get("/api/v1/section/introduction")
+        data = response.json()
+
+        assert data["path"] == "/introduction"
+        assert data["title"] == "Introduction"
+        assert data["level"] == 1
+        assert "location" in data
+
+    def test_get_section_with_nested_path(self, client: TestClient):
+        """Nested paths work correctly."""
+        response = client.get("/api/v1/section/introduction/goals")
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["path"] == "/introduction/goals"
+        assert data["title"] == "Goals"
+        assert data["level"] == 2
+
+    def test_get_section_returns_404_for_nonexistent(self, client: TestClient):
+        """AC-NAV-04: Returns 404 for non-existent path."""
+        response = client.get("/api/v1/section/nonexistent/path")
+
+        assert response.status_code == 404
+        data = response.json()
+        # FastAPI wraps HTTPException detail in "detail" key
+        assert data["detail"]["error"]["code"] == "PATH_NOT_FOUND"
+
+    def test_get_section_404_includes_message(self, client: TestClient):
+        """AC-NAV-04: 404 includes error message with path."""
+        response = client.get("/api/v1/section/nonexistent")
+        data = response.json()
+
+        assert "nonexistent" in data["detail"]["error"]["message"]
+
+    def test_get_section_location_has_file_and_line(self, client: TestClient):
+        """Location includes file and line information."""
+        response = client.get("/api/v1/section/introduction")
+        data = response.json()
+
+        assert data["location"]["file"] == "docs/intro.adoc"
+        assert data["location"]["line"] == 1
+
+
+class TestGetSections:
+    """Tests for GET /api/v1/sections endpoint."""
+
+    def test_get_sections_at_level_1(self, client: TestClient):
+        """AC-NAV-05: GET /sections?level=1 returns level 1 sections."""
+        response = client.get("/api/v1/sections?level=1")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["level"] == 1
+        assert "sections" in data
+        assert "count" in data
+        assert data["count"] == 2
+
+        # All sections should be level 1
+        for section in data["sections"]:
+            assert section["path"] in ["/introduction", "/constraints"]
+
+    def test_get_sections_at_level_2(self, client: TestClient):
+        """GET /sections?level=2 returns level 2 sections."""
+        response = client.get("/api/v1/sections?level=2")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["level"] == 2
+        assert data["count"] == 3  # goals, scope, technical
+
+    def test_get_sections_returns_empty_for_nonexistent_level(self, client: TestClient):
+        """Returns empty list for level with no sections."""
+        response = client.get("/api/v1/sections?level=5")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["level"] == 5
+        assert data["sections"] == []
+        assert data["count"] == 0
+
+    def test_get_sections_requires_level_parameter(self, client: TestClient):
+        """Level parameter is required."""
+        response = client.get("/api/v1/sections")
+
+        assert response.status_code == 422  # Validation error
+
+
+class TestEmptyIndex:
+    """Tests for API behavior with empty index."""
+
+    @pytest.fixture
+    def empty_client(self) -> TestClient:
+        """Create a test client with empty index."""
+        index = StructureIndex()
+        index.build_from_documents([])
+        app = create_app(index)
+        return TestClient(app)
+
+    def test_empty_structure_returns_200(self, empty_client: TestClient):
+        """Empty index returns 200 with empty structure."""
+        response = empty_client.get("/api/v1/structure")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["sections"] == []
+        assert data["total_sections"] == 0
+
+    def test_empty_sections_returns_200(self, empty_client: TestClient):
+        """Empty index returns 200 with empty sections list."""
+        response = empty_client.get("/api/v1/sections?level=1")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["sections"] == []
+        assert data["count"] == 0


### PR DESCRIPTION
## Summary
- Implements FastAPI-based Navigation API with three endpoints
- GET /api/v1/structure - Hierarchical document structure with optional max_depth filtering
- GET /api/v1/section/{path} - Single section lookup by path with 404 handling
- GET /api/v1/sections?level=N - All sections at a specific nesting level

## Changes
- New `src/mcp_server/api/` package with:
  - `app.py` - FastAPI application factory
  - `models.py` - Pydantic response models
  - `navigation.py` - Navigation router with 3 endpoints
- 18 new tests in `tests/test_navigation_api.py`

## Test Results
All 157 tests pass (18 new for Navigation API)

## Tech Debt
Created Issue #35 for items not yet implemented:
- Content reading endpoint
- end_line tracking in responses
- Path suggestions in 404 errors

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)