### PR TITLE
feat(mcp): Add get_sections_at_level tool

### DIFF
--- a/src/mcp_server/mcp_app.py
+++ b/src/mcp_server/mcp_app.py
@@ -139,6 +139,35 @@ def create_mcp_server(docs_root: Path | str | None = None) -> FastMCP:
             return {"error": f"Failed to read section content: {e}"}
 
     @mcp.tool()
+    def get_sections_at_level(level: int) -> dict:
+        """Get all sections at a specific nesting level.
+
+        Use this tool to retrieve all sections at a particular level of the
+        document hierarchy. Level 1 represents chapters/top-level sections,
+        level 2 represents sub-sections, etc.
+
+        Args:
+            level: Nesting level (1 = chapters, 2 = sections, 3 = sub-sections, etc.)
+
+        Returns:
+            Dictionary with 'level', 'sections' (list with path and title),
+            and 'count'.
+        """
+        sections = index.get_sections_at_level(level)
+
+        return {
+            "level": level,
+            "sections": [
+                {
+                    "path": s.path,
+                    "title": s.title,
+                }
+                for s in sections
+            ],
+            "count": len(sections),
+        }
+
+    @mcp.tool()
     def search(
         query: str,
         scope: str | None = None,

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -63,6 +63,7 @@ class TestToolDiscovery:
         expected_tools = {
             "get_structure",
             "get_section",
+            "get_sections_at_level",
             "search",
             "update_section",
             "insert_content",
@@ -132,6 +133,60 @@ class TestGetSection:
 
         # Implementation returns dict with "error" key for not found
         assert "error" in result.data
+
+
+class TestGetSectionsAtLevel:
+    """Tests for get_sections_at_level tool."""
+
+    async def test_get_level_1_sections(self, mcp_client: Client):
+        """get_sections_at_level returns sections at level 1 (chapters)."""
+        result = await mcp_client.call_tool(
+            "get_sections_at_level", arguments={"level": 1}
+        )
+
+        assert "level" in result.data
+        assert result.data["level"] == 1
+        assert "sections" in result.data
+        assert "count" in result.data
+
+        # Test document has 2 level-1 sections: Introduction, Constraints
+        sections = result.data["sections"]
+        assert len(sections) == 2
+        titles = [s["title"] for s in sections]
+        assert "Introduction" in titles
+        assert "Constraints" in titles
+
+    async def test_get_level_2_sections(self, mcp_client: Client):
+        """get_sections_at_level returns sections at level 2 (sub-sections)."""
+        result = await mcp_client.call_tool(
+            "get_sections_at_level", arguments={"level": 2}
+        )
+
+        assert result.data["level"] == 2
+        sections = result.data["sections"]
+        # Test document has 1 level-2 section: Goals
+        assert len(sections) == 1
+        assert sections[0]["title"] == "Goals"
+
+    async def test_get_sections_empty_level(self, mcp_client: Client):
+        """get_sections_at_level returns empty list for levels with no sections."""
+        result = await mcp_client.call_tool(
+            "get_sections_at_level", arguments={"level": 5}
+        )
+
+        assert result.data["level"] == 5
+        assert result.data["sections"] == []
+        assert result.data["count"] == 0
+
+    async def test_get_sections_has_path_and_title(self, mcp_client: Client):
+        """get_sections_at_level returns sections with path and title."""
+        result = await mcp_client.call_tool(
+            "get_sections_at_level", arguments={"level": 1}
+        )
+
+        for section in result.data["sections"]:
+            assert "path" in section
+            assert "title" in section
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Implements the `get_sections_at_level` MCP tool from Issue #48
- Adds 4 comprehensive tests for the new tool

## Changes
- **src/mcp_server/mcp_app.py**: Add `get_sections_at_level` tool that retrieves all sections at a specific nesting level
- **tests/test_mcp_tools.py**: Add test class with 4 tests covering level filtering, empty levels, and response format validation

## Response Format
```json
{
  "level": 1,
  "sections": [
    {"path": "introduction", "title": "Introduction"},
    {"path": "constraints", "title": "Constraints"}
  ],
  "count": 2
}
```

## Test Plan
- [x] New tests for `get_sections_at_level` tool pass
- [x] All 254 existing tests pass
- [x] Linting passes

## Related
- Closes part of Issue #48 (remaining items: path format standardization, MCP Inspector testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)