### PR TITLE
feat(parsers): Standardize path format without document title prefix

### DIFF
--- a/src/mcp_server/asciidoc_parser.py
+++ b/src/mcp_server/asciidoc_parser.py
@@ -426,7 +426,7 @@ class AsciidocParser:
                 # Document title (level 0)
                 if level == 0:
                     document_title = title
-                    section.path = _title_to_slug(title)
+                    section.path = ""  # Empty path for document title per API spec
                     sections.append(section)
                     section_stack = [section]
                 else:
@@ -434,13 +434,18 @@ class AsciidocParser:
                     while section_stack and section_stack[-1].level >= level:
                         section_stack.pop()
 
+                    slug = _title_to_slug(title)
                     if section_stack:
                         parent = section_stack[-1]
-                        section.path = f"{parent.path}.{_title_to_slug(title)}"
+                        # If parent is document title (level 0), don't prefix
+                        if parent.level == 0:
+                            section.path = slug
+                        else:
+                            section.path = f"{parent.path}.{slug}"
                         parent.children.append(section)
                     else:
                         # No parent found, add as top-level
-                        section.path = _title_to_slug(title)
+                        section.path = slug
                         sections.append(section)
 
                     section_stack.append(section)

--- a/src/mcp_server/markdown_parser.py
+++ b/src/mcp_server/markdown_parser.py
@@ -679,8 +679,12 @@ class MarkdownParser:
             level: Heading level
 
         Returns:
-            Hierarchical path string
+            Hierarchical path string (dot-separated, no document title prefix)
         """
+        # H1 (document title) has empty path per API spec
+        if level == 1:
+            return ""
+
         slug = slugify(title)
 
         # Find ancestors at lower levels
@@ -690,10 +694,14 @@ class MarkdownParser:
                 ancestors.append(s)
 
         if ancestors:
-            parent_path = ancestors[-1].path
-            return f"{parent_path}/{slug}"
+            parent = ancestors[-1]
+            # If parent is H1 (document title), don't prefix with parent path
+            if parent.level == 1:
+                return slug
+            else:
+                return f"{parent.path}.{slug}"
         else:
-            return f"/{slug}"
+            return slug
 
     def _find_section_by_path(
         self, sections: list[Section], path: str

--- a/tests/test_asciidoc_parser.py
+++ b/tests/test_asciidoc_parser.py
@@ -112,28 +112,30 @@ class TestSectionPaths:
     """Tests for hierarchical section paths."""
 
     def test_root_section_path(self):
-        """Test that root section has correct path."""
+        """Test that root section (document title) has empty path."""
         from mcp_server.asciidoc_parser import AsciidocParser
 
         parser = AsciidocParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
-        assert root.path == "haupttitel"
+        # Document title (level 0) has empty path per API spec
+        assert root.path == ""
 
     def test_chapter_section_path(self):
-        """Test that chapter sections have correct hierarchical paths."""
+        """Test that chapter sections have paths without document title prefix."""
         from mcp_server.asciidoc_parser import AsciidocParser
 
         parser = AsciidocParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
-        assert root.children[0].path == "haupttitel.kapitel-1"
-        assert root.children[1].path == "haupttitel.kapitel-2"
+        # Level 1 sections have slug-only paths (no document title prefix)
+        assert root.children[0].path == "kapitel-1"
+        assert root.children[1].path == "kapitel-2"
 
     def test_subsection_path(self):
-        """Test that subsections have correct hierarchical paths."""
+        """Test that subsections have hierarchical paths with dot-separation."""
         from mcp_server.asciidoc_parser import AsciidocParser
 
         parser = AsciidocParser(base_path=FIXTURES_DIR)
@@ -141,7 +143,8 @@ class TestSectionPaths:
 
         root = doc.sections[0]
         unterkapitel = root.children[1].children[0]
-        assert unterkapitel.path == "haupttitel.kapitel-2.unterkapitel"
+        # Level 2+ sections have parent.slug format
+        assert unterkapitel.path == "kapitel-2.unterkapitel"
 
 
 class TestSourceLocation:
@@ -527,7 +530,7 @@ class TestInterfaceMethods:
         parser = AsciidocParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
-        section = parser.get_section(doc, "haupttitel.kapitel-1")
+        section = parser.get_section(doc, "kapitel-1")
         assert section is not None
         assert section.title == "Kapitel 1"
 
@@ -548,7 +551,7 @@ class TestInterfaceMethods:
         parser = AsciidocParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
-        section = parser.get_section(doc, "haupttitel.kapitel-2.unterkapitel")
+        section = parser.get_section(doc, "kapitel-2.unterkapitel")
         assert section is not None
         assert section.title == "Unterkapitel"
 

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -161,10 +161,11 @@ class TestHeadingPaths:
             f.flush()
             doc = parser.parse_file(Path(f.name))
 
-        assert doc.sections[0].path == "/haupttitel"
+        # Document title (H1) has empty path per API spec
+        assert doc.sections[0].path == ""
 
     def test_nested_heading_paths(self):
-        """Nested headings have correct hierarchical paths."""
+        """Nested headings have correct hierarchical paths with dot-separation."""
         from mcp_server.markdown_parser import MarkdownParser
 
         parser = MarkdownParser()
@@ -185,10 +186,13 @@ class TestHeadingPaths:
             doc = parser.parse_file(Path(f.name))
 
         root = doc.sections[0]
-        assert root.path == "/haupttitel"
-        assert root.children[0].path == "/haupttitel/unterkapitel-1"
-        assert root.children[1].path == "/haupttitel/unterkapitel-2"
-        assert root.children[1].children[0].path == "/haupttitel/unterkapitel-2/sub-unterkapitel"
+        # H1 (document title) has empty path
+        assert root.path == ""
+        # H2 sections have slug-only paths (no document title prefix)
+        assert root.children[0].path == "unterkapitel-1"
+        assert root.children[1].path == "unterkapitel-2"
+        # H3+ sections have parent.slug format with dot-separation
+        assert root.children[1].children[0].path == "unterkapitel-2.sub-unterkapitel"
 
     def test_path_slugification(self):
         """Paths are properly slugified (lowercase, dashes)."""
@@ -203,8 +207,8 @@ class TestHeadingPaths:
             f.flush()
             doc = parser.parse_file(Path(f.name))
 
-        # Should be slugified
-        assert doc.sections[0].path == "/my-great-title"
+        # Document title has empty path (per API spec)
+        assert doc.sections[0].path == ""
 
 
 class TestSourceLocation:
@@ -539,7 +543,7 @@ code
             doc = parser.parse_file(Path(f.name))
 
         code_block = doc.elements[0]
-        assert code_block.parent_section == "/root/code-section"
+        assert code_block.parent_section == "code-section"
 
     def test_multiple_code_blocks(self):
         """Multiple code blocks are extracted."""
@@ -1041,7 +1045,7 @@ class TestInterfaceMethods:
             f.flush()
             doc = parser.parse_file(Path(f.name))
 
-        section = parser.get_section(doc, "/root/chapter")
+        section = parser.get_section(doc, "chapter")
         assert section is not None
         assert section.title == "Chapter"
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -115,9 +115,9 @@ class TestGetSection:
     async def test_get_section_returns_content(self, mcp_client: Client):
         """get_section returns section with content."""
         # Note: Paths use dot notation with document title prefix
-        # e.g., "test-document.introduction" not "/introduction"
+        # e.g., "introduction" not "/introduction"
         result = await mcp_client.call_tool(
-            "get_section", arguments={"path": "test-document.introduction"}
+            "get_section", arguments={"path": "introduction"}
         )
 
         assert result.data is not None
@@ -239,7 +239,7 @@ class TestUpdateSection:
         result = await mcp_client.call_tool(
             "update_section",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "content": "== Introduction\n\nUpdated content.\n",
             },
         )
@@ -258,7 +258,7 @@ class TestUpdateSection:
         result = await mcp_client.call_tool(
             "update_section",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "content": "New body content only.\n",
                 "preserve_title": True,
             },
@@ -282,7 +282,7 @@ class TestInsertContent:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "position": "after",
                 "content": "== New Section\n\nNew content.\n",
             },
@@ -309,7 +309,7 @@ class TestInsertContent:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "position": "before",
                 "content": "== Preface\n\nPreface content.\n",
             },
@@ -333,7 +333,7 @@ class TestInsertContent:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "position": "invalid",
                 "content": "Some content",
             },
@@ -359,7 +359,7 @@ class TestIndexRebuildAfterWrite:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.constraints",
+                "path": "constraints",
                 "position": "after",
                 "content": "== Brand New Section\n\nThis is brand new content.\n",
             },
@@ -370,7 +370,7 @@ class TestIndexRebuildAfterWrite:
         structure = await mcp_client.call_tool("get_structure", arguments={})
         all_paths = self._extract_all_paths(structure.data["sections"])
 
-        assert "test-document.brand-new-section" in all_paths
+        assert "brand-new-section" in all_paths
 
     async def test_index_updated_after_update_section(
         self, mcp_client: Client, temp_doc_dir: Path
@@ -384,7 +384,7 @@ class TestIndexRebuildAfterWrite:
         result = await mcp_client.call_tool(
             "update_section",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "content": "Updated introduction with more text.\n\nAnother paragraph.\n",
                 "preserve_title": True,
             },
@@ -397,7 +397,7 @@ class TestIndexRebuildAfterWrite:
 
         # The section should still be accessible
         section = await mcp_client.call_tool(
-            "get_section", arguments={"path": "test-document.introduction"}
+            "get_section", arguments={"path": "introduction"}
         )
         assert "error" not in section.data
         assert "Updated introduction" in section.data["content"]
@@ -416,7 +416,7 @@ class TestIndexRebuildAfterWrite:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.constraints",
+                "path": "constraints",
                 "position": "after",
                 "content": "== Another Chapter\n\nChapter content.\n",
             },
@@ -440,7 +440,7 @@ class TestIndexRebuildAfterWrite:
         result = await mcp_client.call_tool(
             "insert_content",
             arguments={
-                "path": "test-document.introduction",
+                "path": "introduction",
                 "position": "after",
                 "content": "== Zephyr Unique Title\n\nSome content.\n",
             },

--- a/tests/test_structure_index.py
+++ b/tests/test_structure_index.py
@@ -39,7 +39,7 @@ class TestIndexBuilding:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     children=[],
                 )
@@ -61,7 +61,7 @@ class TestIndexBuilding:
                 Section(
                     title="Section A",
                     level=1,
-                    path="/section-a",
+                    path="section-a",
                     source_location=SourceLocation(file=Path("doc1.adoc"), line=1),
                 )
             ],
@@ -73,7 +73,7 @@ class TestIndexBuilding:
                 Section(
                     title="Section B",
                     level=1,
-                    path="/section-b",
+                    path="section-b",
                     source_location=SourceLocation(file=Path("doc2.md"), line=1),
                 )
             ],
@@ -93,13 +93,13 @@ class TestIndexBuilding:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Section 1.1",
                             level=2,
-                            path="/chapter-1/section-1-1",
+                            path="chapter-1.section-1-1",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=10
                             ),
@@ -111,8 +111,8 @@ class TestIndexBuilding:
         index.build_from_documents([doc])
 
         # Both parent and child should be findable
-        assert index.get_section("/chapter-1") is not None
-        assert index.get_section("/chapter-1/section-1-1") is not None
+        assert index.get_section("chapter-1") is not None
+        assert index.get_section("chapter-1.section-1-1") is not None
 
     def test_elements_are_indexed(self):
         """Elements from documents are indexed."""
@@ -126,13 +126,13 @@ class TestIndexBuilding:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={"language": "python"},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="table",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     attributes={"columns": 3},
-                    parent_section="/data",
+                    parent_section="data",
                 ),
             ],
         )
@@ -155,13 +155,13 @@ class TestGetStructure:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Section 1.1",
                             level=2,
-                            path="/chapter-1/section-1-1",
+                            path="chapter-1.section-1-1",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=10
                             ),
@@ -171,7 +171,7 @@ class TestGetStructure:
                 Section(
                     title="Chapter 2",
                     level=1,
-                    path="/chapter-2",
+                    path="chapter-2",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                 ),
             ],
@@ -194,13 +194,13 @@ class TestGetStructure:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Section 1.1",
                             level=2,
-                            path="/chapter-1/section-1-1",
+                            path="chapter-1.section-1-1",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=10
                             ),
@@ -208,7 +208,7 @@ class TestGetStructure:
                                 Section(
                                     title="Subsection 1.1.1",
                                     level=3,
-                                    path="/chapter-1/section-1-1/subsection-1-1-1",
+                                    path="chapter-1.section-1-1/subsection-1-1-1",
                                     source_location=SourceLocation(
                                         file=Path("test.adoc"), line=15
                                     ),
@@ -245,14 +245,14 @@ class TestGetSection:
                 Section(
                     title="Introduction",
                     level=1,
-                    path="/introduction",
+                    path="introduction",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                 )
             ],
         )
         index.build_from_documents([doc])
 
-        section = index.get_section("/introduction")
+        section = index.get_section("introduction")
         assert section is not None
         assert section.title == "Introduction"
         assert section.source_location.line == 5
@@ -262,7 +262,7 @@ class TestGetSection:
         index = StructureIndex()
         index.build_from_documents([])
 
-        section = index.get_section("/nonexistent")
+        section = index.get_section("nonexistent")
         assert section is None
 
     def test_get_section_finds_nested_sections(self):
@@ -275,13 +275,13 @@ class TestGetSection:
                 Section(
                     title="Chapter",
                     level=1,
-                    path="/chapter",
+                    path="chapter",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Section",
                             level=2,
-                            path="/chapter/section",
+                            path="chapter.section",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=10
                             ),
@@ -289,7 +289,7 @@ class TestGetSection:
                                 Section(
                                     title="Subsection",
                                     level=3,
-                                    path="/chapter/section/subsection",
+                                    path="chapter.section/subsection",
                                     source_location=SourceLocation(
                                         file=Path("test.adoc"), line=20
                                     ),
@@ -302,7 +302,7 @@ class TestGetSection:
         )
         index.build_from_documents([doc])
 
-        section = index.get_section("/chapter/section/subsection")
+        section = index.get_section("chapter.section/subsection")
         assert section is not None
         assert section.title == "Subsection"
 
@@ -320,13 +320,13 @@ class TestGetSectionsAtLevel:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Section 1.1",
                             level=2,
-                            path="/chapter-1/section-1-1",
+                            path="chapter-1.section-1-1",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=5
                             ),
@@ -336,13 +336,13 @@ class TestGetSectionsAtLevel:
                 Section(
                     title="Chapter 2",
                     level=1,
-                    path="/chapter-2",
+                    path="chapter-2",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     children=[
                         Section(
                             title="Section 2.1",
                             level=2,
-                            path="/chapter-2/section-2-1",
+                            path="chapter-2.section-2-1",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=25
                             ),
@@ -385,13 +385,13 @@ class TestGetElements:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={"language": "python"},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="table",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     attributes={"columns": 3},
-                    parent_section="/data",
+                    parent_section="data",
                 ),
             ],
         )
@@ -412,19 +412,19 @@ class TestGetElements:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={"language": "python"},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=15),
                     attributes={"language": "java"},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="table",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     attributes={"columns": 3},
-                    parent_section="/data",
+                    parent_section="data",
                 ),
             ],
         )
@@ -449,19 +449,19 @@ class TestGetElements:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={"language": "python"},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=15),
                     attributes={"language": "java"},
-                    parent_section="/chapter-1",
+                    parent_section="chapter-1",
                 ),
             ],
         )
         index.build_from_documents([doc])
 
-        intro_elements = index.get_elements(section_path="/intro")
+        intro_elements = index.get_elements(section_path="intro")
         assert len(intro_elements) == 1
         assert intro_elements[0].attributes["language"] == "python"
 
@@ -477,25 +477,25 @@ class TestGetElements:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="table",
                     source_location=SourceLocation(file=Path("test.adoc"), line=10),
                     attributes={},
-                    parent_section="/intro",
+                    parent_section="intro",
                 ),
                 Element(
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     attributes={},
-                    parent_section="/chapter-1",
+                    parent_section="chapter-1",
                 ),
             ],
         )
         index.build_from_documents([doc])
 
-        elements = index.get_elements(element_type="code", section_path="/intro")
+        elements = index.get_elements(element_type="code", section_path="intro")
         assert len(elements) == 1
 
 
@@ -512,13 +512,13 @@ class TestSearch:
                 Section(
                     title="Introduction to Python",
                     level=1,
-                    path="/introduction",
+                    path="introduction",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 ),
                 Section(
                     title="Java Basics",
                     level=1,
-                    path="/java-basics",
+                    path="java-basics",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                 ),
             ],
@@ -527,7 +527,7 @@ class TestSearch:
 
         results = index.search("Python")
         assert len(results) == 1
-        assert results[0].path == "/introduction"
+        assert results[0].path == "introduction"
 
     def test_search_is_case_insensitive_by_default(self):
         """search() is case-insensitive by default."""
@@ -539,7 +539,7 @@ class TestSearch:
                 Section(
                     title="Python Tutorial",
                     level=1,
-                    path="/python",
+                    path="python",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 )
             ],
@@ -562,7 +562,7 @@ class TestSearch:
                 Section(
                     title="Python Tutorial",
                     level=1,
-                    path="/python",
+                    path="python",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 )
             ],
@@ -582,7 +582,7 @@ class TestSearch:
             Section(
                 title=f"Section {i}",
                 level=1,
-                path=f"/section-{i}",
+                path=f"section-{i}",
                 source_location=SourceLocation(file=Path("test.adoc"), line=i * 10),
             )
             for i in range(10)
@@ -607,13 +607,13 @@ class TestSearch:
                 Section(
                     title="Chapter 1",
                     level=1,
-                    path="/chapter-1",
+                    path="chapter-1",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                     children=[
                         Section(
                             title="Python Section",
                             level=2,
-                            path="/chapter-1/python",
+                            path="chapter-1.python",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=5
                             ),
@@ -623,13 +623,13 @@ class TestSearch:
                 Section(
                     title="Chapter 2",
                     level=1,
-                    path="/chapter-2",
+                    path="chapter-2",
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                     children=[
                         Section(
                             title="Python Advanced",
                             level=2,
-                            path="/chapter-2/python",
+                            path="chapter-2.python",
                             source_location=SourceLocation(
                                 file=Path("test.adoc"), line=25
                             ),
@@ -641,9 +641,9 @@ class TestSearch:
         index.build_from_documents([doc])
 
         # Search within chapter-1 scope
-        results = index.search("Python", scope="/chapter-1")
+        results = index.search("Python", scope="chapter-1")
         assert len(results) == 1
-        assert results[0].path == "/chapter-1/python"
+        assert results[0].path == "chapter-1.python"
 
 
 class TestDuplicateDetection:
@@ -659,13 +659,13 @@ class TestDuplicateDetection:
                 Section(
                     title="Section A",
                     level=1,
-                    path="/section",
+                    path="section",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 ),
                 Section(
                     title="Section B",
                     level=1,
-                    path="/section",  # Duplicate path!
+                    path="section",  # Duplicate path!
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                 ),
             ],
@@ -686,13 +686,13 @@ class TestDuplicateDetection:
                 Section(
                     title="Section A",
                     level=1,
-                    path="/section",
+                    path="section",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 ),
                 Section(
                     title="Section B",
                     level=1,
-                    path="/section",  # Duplicate path!
+                    path="section",  # Duplicate path!
                     source_location=SourceLocation(file=Path("test.adoc"), line=20),
                 ),
             ],
@@ -703,7 +703,7 @@ class TestDuplicateDetection:
         assert len(warnings) == 1
 
         # Only first section should be indexed
-        section = index.get_section("/section")
+        section = index.get_section("section")
         assert section is not None
         assert section.title == "Section A"
         assert section.source_location.line == 1
@@ -727,7 +727,7 @@ class TestClearAndStats:
                 Section(
                     title="Chapter",
                     level=1,
-                    path="/chapter",
+                    path="chapter",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 )
             ],
@@ -748,7 +748,7 @@ class TestClearAndStats:
                 Section(
                     title="Chapter",
                     level=1,
-                    path="/chapter",
+                    path="chapter",
                     source_location=SourceLocation(file=Path("test.adoc"), line=1),
                 )
             ],
@@ -757,7 +757,7 @@ class TestClearAndStats:
                     type="code",
                     source_location=SourceLocation(file=Path("test.adoc"), line=5),
                     attributes={},
-                    parent_section="/chapter",
+                    parent_section="chapter",
                 )
             ],
         )


### PR DESCRIPTION
## Summary
- Standardizes path format across AsciiDoc and Markdown parsers to match API specification
- Document title (level 0) now has empty path `""`
- Level 1 sections have slug-only paths without document title prefix
- Level 2+ sections use dot-separation (e.g., `parent.section`)

## Changes
- **AsciiDoc Parser**: Modified path generation to exclude document title prefix
- **Markdown Parser**: Changed from slash-separation to dot-separation, removed leading slash
- **Tests**: Updated all path assertions to use new format

## New Path Format (API-spec compliant)
| Level | Old Format | New Format |
|-------|-----------|------------|
| 0 (doc title) | `haupttitel` | `""` |
| 1 (chapter) | `haupttitel.kapitel-1` | `kapitel-1` |
| 2 (section) | `haupttitel.kapitel-2.unterkapitel` | `kapitel-2.unterkapitel` |

## Test plan
- [x] All 266 tests passing
- [x] Manual verification of path format
- [x] Linter passes

Closes #48 (path format standardization part)

🤖 Generated with [Claude Code](https://claude.com/claude-code)