### PR TITLE
feat(navigation): Add path suggestions for 404 responses (#35)

### DIFF
--- a/src/mcp_server/mcp_app.py
+++ b/src/mcp_server/mcp_app.py
@@ -115,7 +115,17 @@ def create_mcp_server(docs_root: Path | str | None = None) -> FastMCP:
 
         section = index.get_section(normalized_path)
         if section is None:
-            return {"error": "Section not found", "path": normalized_path}
+            suggestions = index.get_suggestions(normalized_path)
+            return {
+                "error": {
+                    "code": "PATH_NOT_FOUND",
+                    "message": f"Section '{normalized_path}' not found",
+                    "details": {
+                        "requested_path": normalized_path,
+                        "suggestions": suggestions,
+                    },
+                }
+            }
 
         # Read actual content from file
         try:


### PR DESCRIPTION
## Summary
- Add path suggestions when a section is not found (404 response)
- Implements smart suggestion algorithm using prefix/suffix matching
- Error response now matches API specification format

## Changes
- Add `get_suggestions()` method to StructureIndex
- Add `_calculate_path_similarity()` helper for scoring paths
- Update `get_section()` error response format in mcp_app.py

## Scoring Algorithm
| Match Type | Points |
|------------|--------|
| Same parent path | +10 |
| Same last segment | +5 |
| Partial last segment | +3 |
| Same first segment | +2 |

## Example Response
```json
{
  "error": {
    "code": "PATH_NOT_FOUND",
    "message": "Section 'introduction.goal' not found",
    "details": {
      "requested_path": "introduction.goal",
      "suggestions": ["introduction.goals", "introduction.quality-goals"]
    }
  }
}
```

## Test Coverage
- 5 new tests for `get_suggestions()` method
- All 286 tests pass

## Test plan
- [x] Run `uv run pytest` - all tests pass
- [x] TDD workflow followed
- [x] Code review completed

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)