### PR TITLE
refactor: Rename parsers to *StructureParser for clarity (#63)

### DIFF
--- a/src/mcp_server/asciidoc_parser.py
+++ b/src/mcp_server/asciidoc_parser.py
@@ -1,6 +1,6 @@
 """AsciiDoc Parser for MCP Documentation Server.
 
-This module provides the AsciidocParser class for parsing AsciiDoc documents.
+This module provides the AsciidocStructureParser class for parsing AsciiDoc documents.
 It supports section extraction (AC-ADOC-01), attributes (AC-ADOC-02),
 includes (AC-ADOC-03, AC-ADOC-04), structural elements (AC-ADOC-05,
 AC-ADOC-06, AC-ADOC-07), and cross-references (AC-ADOC-08).
@@ -106,7 +106,7 @@ class AsciidocDocument(Document):
     includes: list[IncludeInfo] = field(default_factory=list)
 
 
-class AsciidocParser:
+class AsciidocStructureParser:
     """Parser for AsciiDoc documents.
 
     Parses AsciiDoc files and extracts structure, elements, cross-references,

--- a/src/mcp_server/markdown_parser.py
+++ b/src/mcp_server/markdown_parser.py
@@ -88,7 +88,7 @@ class FolderDocument:
     structure: list[Section] = field(default_factory=list)
 
 
-class MarkdownParser:
+class MarkdownStructureParser:
     """Parser for GitHub Flavored Markdown documents.
 
     Parses single files or entire folder hierarchies into structured

--- a/src/mcp_server/mcp_app.py
+++ b/src/mcp_server/mcp_app.py
@@ -20,9 +20,9 @@ from pathlib import Path
 from fastmcp import FastMCP
 
 from mcp_server import __version__
-from mcp_server.asciidoc_parser import AsciidocParser
+from mcp_server.asciidoc_parser import AsciidocStructureParser
 from mcp_server.file_handler import FileReadError, FileSystemHandler, FileWriteError
-from mcp_server.markdown_parser import MarkdownParser
+from mcp_server.markdown_parser import MarkdownStructureParser
 from mcp_server.models import Document, Section
 from mcp_server.structure_index import StructureIndex
 
@@ -61,8 +61,8 @@ def create_mcp_server(docs_root: Path | str | None = None) -> FastMCP:
     # Initialize components
     index = StructureIndex()
     file_handler = FileSystemHandler()
-    asciidoc_parser = AsciidocParser(base_path=docs_root)
-    markdown_parser = MarkdownParser()
+    asciidoc_parser = AsciidocStructureParser(base_path=docs_root)
+    markdown_parser = MarkdownStructureParser()
 
     # Build initial index
     _build_index(docs_root, index, asciidoc_parser, markdown_parser)
@@ -505,8 +505,8 @@ def create_mcp_server(docs_root: Path | str | None = None) -> FastMCP:
 def _build_index(
     docs_root: Path,
     index: StructureIndex,
-    asciidoc_parser: AsciidocParser,
-    markdown_parser: MarkdownParser,
+    asciidoc_parser: AsciidocStructureParser,
+    markdown_parser: MarkdownStructureParser,
 ) -> None:
     """Build the structure index from documents in docs_root.
 

--- a/tests/test_asciidoc_parser.py
+++ b/tests/test_asciidoc_parser.py
@@ -17,29 +17,29 @@ import pytest
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "asciidoc"
 
 
-class TestAsciidocParserBasic:
-    """Basic tests for AsciidocParser instantiation."""
+class TestAsciidocStructureParserBasic:
+    """Basic tests for AsciidocStructureParser instantiation."""
 
     def test_parser_can_be_instantiated(self):
-        """Test that AsciidocParser can be instantiated with a base path."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        """Test that AsciidocStructureParser can be instantiated with a base path."""
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=Path("."))
+        parser = AsciidocStructureParser(base_path=Path("."))
         assert parser is not None
         assert parser.base_path == Path(".")
 
     def test_parser_accepts_max_include_depth(self):
         """Test that parser accepts max_include_depth parameter."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=Path("."), max_include_depth=10)
+        parser = AsciidocStructureParser(base_path=Path("."), max_include_depth=10)
         assert parser.max_include_depth == 10
 
     def test_parser_default_max_include_depth_is_20(self):
         """Test that default max_include_depth is 20."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=Path("."))
+        parser = AsciidocStructureParser(base_path=Path("."))
         assert parser.max_include_depth == 20
 
 
@@ -48,27 +48,27 @@ class TestSectionExtraction:
 
     def test_parse_file_returns_asciidoc_document(self):
         """Test that parse_file returns an AsciidocDocument."""
-        from mcp_server.asciidoc_parser import AsciidocDocument, AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocDocument, AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         assert isinstance(doc, AsciidocDocument)
 
     def test_parse_file_extracts_document_title(self):
         """Test that document title is extracted."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         assert doc.title == "Haupttitel"
 
     def test_parse_file_extracts_sections(self):
         """Test that sections are extracted from the document."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         # Document should have a root section (title) with children
@@ -76,9 +76,9 @@ class TestSectionExtraction:
 
     def test_section_levels_are_correct(self):
         """Test that section levels are correctly determined."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         # Root section (= Haupttitel) should be level 0
@@ -95,9 +95,9 @@ class TestSectionExtraction:
 
     def test_nested_sections_hierarchy(self):
         """Test that nested sections form correct hierarchy."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         # Kapitel 2 should have Unterkapitel as child
@@ -113,9 +113,9 @@ class TestSectionPaths:
 
     def test_root_section_path(self):
         """Test that root section (document title) has empty path."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -124,9 +124,9 @@ class TestSectionPaths:
 
     def test_chapter_section_path(self):
         """Test that chapter sections have paths without document title prefix."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -136,9 +136,9 @@ class TestSectionPaths:
 
     def test_subsection_path(self):
         """Test that subsections have hierarchical paths with dot-separation."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -152,9 +152,9 @@ class TestSourceLocation:
 
     def test_section_has_source_location(self):
         """Test that sections have source location."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -164,9 +164,9 @@ class TestSourceLocation:
 
     def test_chapter_source_location(self):
         """Test that chapter has correct source location."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -175,9 +175,9 @@ class TestSourceLocation:
 
     def test_section_has_end_line(self):
         """Test that sections have end_line calculated."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -185,9 +185,9 @@ class TestSourceLocation:
 
     def test_section_end_line_is_before_next_section(self):
         """Test that section end_line is correctly calculated."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         root = doc.sections[0]
@@ -203,9 +203,9 @@ class TestDocumentAttributes:
 
     def test_parse_attributes_from_document(self):
         """Test that document attributes are extracted."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_attributes.adoc")
 
         assert "author" in doc.attributes
@@ -213,9 +213,9 @@ class TestDocumentAttributes:
 
     def test_parse_multiple_attributes(self):
         """Test that multiple attributes are extracted."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_attributes.adoc")
 
         assert doc.attributes["author"] == "Max Mustermann"
@@ -225,9 +225,9 @@ class TestDocumentAttributes:
 
     def test_attribute_in_title_is_resolved(self):
         """Test that attribute references in title are resolved."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_attributes.adoc")
 
         # Title should have {project} resolved to "MCP Server"
@@ -239,9 +239,9 @@ class TestIncludeDirectives:
 
     def test_include_directive_is_recorded(self):
         """Test that include directives are recorded in includes list."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_include.adoc")
 
         assert len(doc.includes) == 1
@@ -249,9 +249,9 @@ class TestIncludeDirectives:
 
     def test_include_directive_source_location(self):
         """Test that include directive has correct source location."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_include.adoc")
 
         assert doc.includes[0].source_location.line == 7
@@ -259,9 +259,9 @@ class TestIncludeDirectives:
 
     def test_included_sections_are_merged(self):
         """Test that sections from included file are merged into document."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_include.adoc")
 
         # Document should have root section with 4 children:
@@ -275,9 +275,9 @@ class TestIncludeDirectives:
 
     def test_included_section_has_resolved_from_info(self):
         """Test that included sections track their source file."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_include.adoc")
 
         root = doc.sections[0]
@@ -303,9 +303,9 @@ class TestElementExtraction:
 
     def test_code_block_is_extracted(self):
         """Test that code blocks are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         code_elements = [e for e in doc.elements if e.type == "code"]
@@ -314,9 +314,9 @@ class TestElementExtraction:
 
     def test_code_block_source_location(self):
         """Test that code block has correct source location."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         code_elements = [e for e in doc.elements if e.type == "code"]
@@ -324,9 +324,9 @@ class TestElementExtraction:
 
     def test_code_block_parent_section(self):
         """Test that code block has correct parent section."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         code_elements = [e for e in doc.elements if e.type == "code"]
@@ -334,9 +334,9 @@ class TestElementExtraction:
 
     def test_table_is_extracted(self):
         """Test that tables are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         table_elements = [e for e in doc.elements if e.type == "table"]
@@ -344,9 +344,9 @@ class TestElementExtraction:
 
     def test_image_is_extracted(self):
         """Test that images are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         image_elements = [e for e in doc.elements if e.type == "image"]
@@ -355,9 +355,9 @@ class TestElementExtraction:
 
     def test_admonition_is_extracted(self):
         """Test that admonitions are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         admonition_elements = [e for e in doc.elements if e.type == "admonition"]
@@ -365,9 +365,9 @@ class TestElementExtraction:
 
     def test_plantuml_block_is_extracted(self):
         """Test that PlantUML blocks are extracted as elements (AC-ADOC-06)."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         plantuml_elements = [e for e in doc.elements if e.type == "plantuml"]
@@ -375,9 +375,9 @@ class TestElementExtraction:
 
     def test_plantuml_block_has_attributes(self):
         """Test that PlantUML block has name and format attributes."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         plantuml_elements = [e for e in doc.elements if e.type == "plantuml"]
@@ -389,7 +389,7 @@ class TestElementExtraction:
         import tempfile
         from pathlib import Path
 
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
         # Create a temporary test file with PlantUML block without attributes
         with tempfile.NamedTemporaryFile(
@@ -409,7 +409,7 @@ Alice -> Bob: Test
             temp_file = Path(f.name)
 
         try:
-            parser = AsciidocParser(base_path=FIXTURES_DIR)
+            parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
             doc = parser.parse_file(temp_file)
 
             plantuml_elements = [e for e in doc.elements if e.type == "plantuml"]
@@ -427,9 +427,9 @@ Alice -> Bob: Test
 
     def test_unordered_list_is_extracted(self):
         """Test that unordered lists are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         list_elements = [e for e in doc.elements if e.type == "list"]
@@ -438,9 +438,9 @@ Alice -> Bob: Test
 
     def test_ordered_list_is_extracted(self):
         """Test that ordered lists are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         list_elements = [e for e in doc.elements if e.type == "list"]
@@ -449,9 +449,9 @@ Alice -> Bob: Test
 
     def test_description_list_is_extracted(self):
         """Test that description lists are extracted as elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         list_elements = [e for e in doc.elements if e.type == "list"]
@@ -460,9 +460,9 @@ Alice -> Bob: Test
 
     def test_list_has_parent_section(self):
         """Test that list element has correct parent section."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         list_elements = [e for e in doc.elements if e.type == "list"]
@@ -477,18 +477,18 @@ class TestCrossReferences:
 
     def test_cross_reference_is_extracted(self):
         """Test that cross-references are extracted."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_xrefs.adoc")
 
         assert len(doc.cross_references) >= 1
 
     def test_cross_reference_target(self):
         """Test that cross-reference target is captured."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_xrefs.adoc")
 
         targets = [xref.target for xref in doc.cross_references]
@@ -497,9 +497,9 @@ class TestCrossReferences:
 
     def test_cross_reference_with_text(self):
         """Test that cross-reference display text is captured."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_xrefs.adoc")
 
         # Find xref with custom text
@@ -511,9 +511,9 @@ class TestCrossReferences:
 
     def test_cross_reference_source_location(self):
         """Test that cross-reference has source location."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_xrefs.adoc")
 
         assert doc.cross_references[0].source_location is not None
@@ -525,9 +525,9 @@ class TestInterfaceMethods:
 
     def test_get_section_returns_section_by_path(self):
         """Test that get_section returns correct section by path."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         section = parser.get_section(doc, "kapitel-1")
@@ -536,9 +536,9 @@ class TestInterfaceMethods:
 
     def test_get_section_returns_none_for_invalid_path(self):
         """Test that get_section returns None for non-existent path."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         section = parser.get_section(doc, "non.existent.path")
@@ -546,9 +546,9 @@ class TestInterfaceMethods:
 
     def test_get_section_returns_nested_section(self):
         """Test that get_section returns deeply nested section."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         section = parser.get_section(doc, "kapitel-2.unterkapitel")
@@ -557,9 +557,9 @@ class TestInterfaceMethods:
 
     def test_get_elements_returns_all_elements(self):
         """Test that get_elements returns all elements."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         elements = parser.get_elements(doc)
@@ -567,9 +567,9 @@ class TestInterfaceMethods:
 
     def test_get_elements_filters_by_type(self):
         """Test that get_elements filters by element type."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "with_elements.adoc")
 
         code_elements = parser.get_elements(doc, element_type="code")
@@ -578,9 +578,9 @@ class TestInterfaceMethods:
 
     def test_get_elements_returns_empty_for_no_match(self):
         """Test that get_elements returns empty list for non-existent type."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         doc = parser.parse_file(FIXTURES_DIR / "simple_sections.adoc")
 
         elements = parser.get_elements(doc, element_type="plantuml")
@@ -592,17 +592,17 @@ class TestCircularIncludeDetection:
 
     def test_circular_include_raises_error(self):
         """Test that circular includes raise CircularIncludeError."""
-        from mcp_server.asciidoc_parser import AsciidocParser, CircularIncludeError
+        from mcp_server.asciidoc_parser import AsciidocStructureParser, CircularIncludeError
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         with pytest.raises(CircularIncludeError):
             parser.parse_file(FIXTURES_DIR / "circular_a.adoc")
 
     def test_circular_include_error_contains_path_info(self):
         """Test that CircularIncludeError contains information about the cycle."""
-        from mcp_server.asciidoc_parser import AsciidocParser, CircularIncludeError
+        from mcp_server.asciidoc_parser import AsciidocStructureParser, CircularIncludeError
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         try:
             parser.parse_file(FIXTURES_DIR / "circular_a.adoc")
             assert False, "Expected CircularIncludeError"
@@ -616,22 +616,22 @@ class TestEdgeCases:
 
     def test_parse_nonexistent_file_raises_error(self):
         """Test that parsing nonexistent file raises FileNotFoundError."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
-        parser = AsciidocParser(base_path=FIXTURES_DIR)
+        parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
         with pytest.raises(FileNotFoundError):
             parser.parse_file(FIXTURES_DIR / "nonexistent.adoc")
 
     def test_parse_empty_file(self):
         """Test that parsing empty file returns document with no sections."""
-        from mcp_server.asciidoc_parser import AsciidocParser
+        from mcp_server.asciidoc_parser import AsciidocStructureParser
 
         # Create empty file
         empty_file = FIXTURES_DIR / "empty.adoc"
         empty_file.write_text("")
 
         try:
-            parser = AsciidocParser(base_path=FIXTURES_DIR)
+            parser = AsciidocStructureParser(base_path=FIXTURES_DIR)
             doc = parser.parse_file(empty_file)
             assert doc.title == ""
             assert doc.sections == []

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -7,21 +7,21 @@ import tempfile
 from pathlib import Path
 
 
-class TestMarkdownParserBasic:
+class TestMarkdownStructureParserBasic:
     """Basic parser instantiation tests."""
 
     def test_parser_can_be_instantiated(self):
         """Parser can be created."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         assert parser is not None
 
     def test_parse_file_returns_markdown_document(self):
         """parse_file returns a MarkdownDocument."""
-        from mcp_server.markdown_parser import MarkdownDocument, MarkdownParser
+        from mcp_server.markdown_parser import MarkdownDocument, MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -38,9 +38,9 @@ class TestHeadingExtraction:
 
     def test_extracts_single_h1_heading(self):
         """Single H1 heading is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -56,9 +56,9 @@ class TestHeadingExtraction:
 
     def test_extracts_multiple_headings(self):
         """Multiple headings at different levels are extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Haupttitel
 
 ## Unterkapitel 1
@@ -99,9 +99,9 @@ Text...
 
     def test_heading_levels_1_to_6(self):
         """All heading levels from 1 to 6 are supported."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# H1
 ## H2
 ### H3
@@ -131,9 +131,9 @@ Text...
 
     def test_heading_with_trailing_hashes(self):
         """Trailing hashes in headings are stripped."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -150,9 +150,9 @@ class TestHeadingPaths:
 
     def test_root_heading_path(self):
         """Root heading has correct path."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -166,9 +166,9 @@ class TestHeadingPaths:
 
     def test_nested_heading_paths(self):
         """Nested headings have correct hierarchical paths with dot-separation."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Haupttitel
 
 ## Unterkapitel 1
@@ -196,9 +196,9 @@ class TestHeadingPaths:
 
     def test_path_slugification(self):
         """Paths are properly slugified (lowercase, dashes)."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -216,9 +216,9 @@ class TestSourceLocation:
 
     def test_heading_has_source_location(self):
         """Headings have correct source location."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ## Chapter
@@ -240,9 +240,9 @@ class TestSourceLocation:
 
     def test_section_has_end_line(self):
         """Sections have end_line calculated."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 Some content.
@@ -264,9 +264,9 @@ Chapter content.
 
     def test_section_end_line_is_before_next_section(self):
         """Section end_line is correctly calculated."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ## Chapter 1
@@ -298,9 +298,9 @@ class TestFrontmatterParsing:
 
     def test_parses_simple_frontmatter(self):
         """Simple string frontmatter is parsed."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 title: Mein Dokument
 author: Max Mustermann
@@ -321,9 +321,9 @@ author: Max Mustermann
 
     def test_parses_list_in_frontmatter(self):
         """List values in frontmatter are parsed."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 tags: [design, architecture]
 ---
@@ -343,9 +343,9 @@ tags: [design, architecture]
 
     def test_parses_nested_object_in_frontmatter(self):
         """Nested objects in frontmatter are parsed."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 author:
   name: Max
@@ -367,9 +367,9 @@ author:
 
     def test_frontmatter_title_overrides_heading(self):
         """Title from frontmatter takes precedence over H1."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 title: Frontmatter Title
 ---
@@ -388,9 +388,9 @@ title: Frontmatter Title
 
     def test_no_frontmatter_is_empty_dict(self):
         """Document without frontmatter has empty frontmatter dict."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Just a heading
 """
 
@@ -405,9 +405,9 @@ title: Frontmatter Title
 
     def test_invalid_frontmatter_is_empty_dict(self):
         """Invalid YAML in frontmatter results in empty dict (with warning)."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 invalid: [not closed
 ---
@@ -427,9 +427,9 @@ invalid: [not closed
 
     def test_headings_after_frontmatter_have_correct_line_numbers(self):
         """Line numbers account for frontmatter offset."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """---
 title: Test
 ---
@@ -453,9 +453,9 @@ class TestCodeBlockExtraction:
 
     def test_extracts_code_block_with_language(self):
         """Code block with language is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Code Examples
 
 ```python
@@ -478,9 +478,9 @@ def hello():
 
     def test_code_block_source_location(self):
         """Code block has correct source location."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ```javascript
@@ -501,9 +501,9 @@ console.log("test");
 
     def test_code_block_without_language(self):
         """Code block without language has empty language attribute."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Code
 
 ```
@@ -523,9 +523,9 @@ plain text
 
     def test_code_block_parent_section(self):
         """Code block has correct parent section."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Root
 
 ## Code Section
@@ -547,9 +547,9 @@ code
 
     def test_multiple_code_blocks(self):
         """Multiple code blocks are extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Examples
 
 ```python
@@ -574,9 +574,9 @@ javascript code
 
     def test_code_block_with_tilde_fence(self):
         """Code block with tilde fence is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Code
 
 ~~~ruby
@@ -596,9 +596,9 @@ puts "hello"
 
     def test_unclosed_code_block_logs_warning(self, caplog):
         """Unclosed code block at end of file logs a warning."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Code
 
 ```python
@@ -630,9 +630,9 @@ class TestCodeBlockContent:
 
     def test_code_block_content_is_extracted(self):
         """Code block content is stored in attributes."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Code Examples
 
 ```python
@@ -655,9 +655,9 @@ def hello():
 
     def test_multiline_code_content_preserved(self):
         """Multi-line code content is preserved with newlines."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Multi-line
 
 ```javascript
@@ -686,9 +686,9 @@ function test() {
 
     def test_empty_code_block_has_empty_content(self):
         """Empty code block has empty string content."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Empty
 
 ```python
@@ -712,9 +712,9 @@ class TestTableRecognition:
 
     def test_extracts_simple_table(self):
         """Simple table is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Data
 
 | Header 1 | Header 2 | Header 3 |
@@ -737,9 +737,9 @@ class TestTableRecognition:
 
     def test_table_row_count(self):
         """Table has correct row count (excluding header)."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Data
 
 | A | B |
@@ -761,9 +761,9 @@ class TestTableRecognition:
 
     def test_table_source_location(self):
         """Table has correct source location."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 Some text.
@@ -789,9 +789,9 @@ class TestImageExtraction:
 
     def test_extracts_image(self):
         """Image is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Images
 
 ![Alt text](path/to/image.png)
@@ -812,9 +812,9 @@ class TestImageExtraction:
 
     def test_image_with_title(self):
         """Image with title is extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Images
 
 ![Diagram](diagram.png "A diagram")
@@ -832,9 +832,9 @@ class TestImageExtraction:
 
     def test_image_source_location(self):
         """Image has correct source location."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ![img](test.png)
@@ -856,9 +856,9 @@ class TestListExtraction:
 
     def test_extracts_unordered_list(self):
         """Test that unordered lists (* or -) are extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Document
 
 ## Lists
@@ -878,9 +878,9 @@ class TestListExtraction:
 
     def test_extracts_ordered_list(self):
         """Test that ordered lists (1.) are extracted."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Document
 
 ## Steps
@@ -900,9 +900,9 @@ class TestListExtraction:
 
     def test_list_has_parent_section(self):
         """Test that list element has correct parent section."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Document
 
 ## My Lists
@@ -921,9 +921,9 @@ class TestListExtraction:
 
     def test_list_source_location(self):
         """Test that list has correct source location."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Document
 
 ## Lists
@@ -946,9 +946,9 @@ class TestFolderStructure:
 
     def test_parse_folder_returns_folder_document(self):
         """parse_folder returns a FolderDocument."""
-        from mcp_server.markdown_parser import FolderDocument, MarkdownParser
+        from mcp_server.markdown_parser import FolderDocument, MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -960,9 +960,9 @@ class TestFolderStructure:
 
     def test_parses_single_file_in_folder(self):
         """Single file in folder is parsed."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -975,9 +975,9 @@ class TestFolderStructure:
 
     def test_parses_multiple_files_in_folder(self):
         """Multiple files in folder are parsed."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -990,9 +990,9 @@ class TestFolderStructure:
 
     def test_parses_nested_folders(self):
         """Nested folders are parsed recursively."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1008,9 +1008,9 @@ class TestFolderStructure:
 
     def test_folder_structure_order(self):
         """Files are in correct order (index first, then sorted)."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1035,9 +1035,9 @@ class TestNumericPrefixSorting:
 
     def test_numeric_prefixes_sorted_correctly(self):
         """Files with numeric prefixes are sorted numerically."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1057,9 +1057,9 @@ class TestNumericPrefixSorting:
 
     def test_readme_comes_first(self):
         """README.md comes before other files."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1073,9 +1073,9 @@ class TestNumericPrefixSorting:
 
     def test_index_comes_first(self):
         """index.md comes before other files."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1089,9 +1089,9 @@ class TestNumericPrefixSorting:
 
     def test_mixed_prefixes_and_names(self):
         """Mixed numeric prefixes and plain names are sorted correctly."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             folder = Path(tmpdir)
@@ -1112,9 +1112,9 @@ class TestInterfaceMethods:
 
     def test_get_section_returns_section_by_path(self):
         """get_section returns correct section."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Root
 
 ## Chapter
@@ -1133,9 +1133,9 @@ class TestInterfaceMethods:
 
     def test_get_section_returns_none_for_invalid_path(self):
         """get_section returns None for invalid path."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", delete=False
@@ -1149,9 +1149,9 @@ class TestInterfaceMethods:
 
     def test_get_elements_returns_all_elements(self):
         """get_elements returns all elements."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ```python
@@ -1173,9 +1173,9 @@ code
 
     def test_get_elements_filters_by_type(self):
         """get_elements filters by type."""
-        from mcp_server.markdown_parser import MarkdownParser
+        from mcp_server.markdown_parser import MarkdownStructureParser
 
-        parser = MarkdownParser()
+        parser = MarkdownStructureParser()
         content = """# Title
 
 ```python


### PR DESCRIPTION
## Summary
Renamed parser classes to better reflect their purpose - they parse document structure, not full syntax:

| Before | After |
|--------|-------|
| `AsciidocParser` | `AsciidocStructureParser` |
| `MarkdownParser` | `MarkdownStructureParser` |

## Rationale
- **Clarity**: The name "StructureParser" clearly communicates what the parser does
- **Expectations**: Prevents confusion - users won't expect full AST or rendered output
- **Consistency**: Aligns with the project's focus on document structure navigation

## Changes
- Renamed classes in source files
- Updated all imports and usages in mcp_app.py
- Updated all test files
- Updated docstrings referencing the class names

## Test plan
- [x] All 290 tests pass
- [x] Linting passes
- [x] Pure rename refactoring - no behavioral changes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)