### PR TITLE
feat(mcp): Add validate_structure tool (Issue #10)

### DIFF
--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -611,3 +611,30 @@ class TestGetMetadata:
         )
 
         assert "error" in result.data
+
+
+class TestValidateStructure:
+    """Tests for validate_structure tool (UC-07)."""
+
+    async def test_validate_structure_returns_valid_true_for_clean_docs(
+        self, mcp_client: Client
+    ):
+        """validate_structure returns valid:true when no errors."""
+        result = await mcp_client.call_tool("validate_structure", arguments={})
+
+        assert "valid" in result.data
+        assert result.data["valid"] is True
+        assert "errors" in result.data
+        assert result.data["errors"] == []
+        assert "warnings" in result.data
+        assert "validation_time_ms" in result.data
+
+    async def test_validate_structure_returns_validation_time(
+        self, mcp_client: Client
+    ):
+        """validate_structure includes validation_time_ms."""
+        result = await mcp_client.call_tool("validate_structure", arguments={})
+
+        assert "validation_time_ms" in result.data
+        assert isinstance(result.data["validation_time_ms"], (int, float))
+        assert result.data["validation_time_ms"] >= 0


### PR DESCRIPTION
## Summary
- Implement `validate_structure` MCP tool as specified in `02_api_specification.adoc:611-652`
- Returns `valid`, `errors`, `warnings`, and `validation_time_ms`
- Currently detects orphaned files (files not indexed in the documentation structure)

## Test plan
- [x] Test: validate_structure returns valid:true for clean docs
- [x] Test: validate_structure returns validation_time_ms
- [x] All 295 tests pass
- [x] Linting passes

## Notes
This completes the second part of Issue #10 (after `get_metadata` in PR #65).

Remaining for Issue #10: `get_dependencies` endpoint (deferred to separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)