### PR TITLE
docs: Update README and create User Manual (Issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,74 @@
 # MCP Documentation Server
 
-Enables LLM interaction with large AsciiDoc/Markdown documentation projects through hierarchical, content-aware access via the Model Context Protocol (MCP).
+[![CI](https://github.com/rdmueller/AsciiDoc-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/rdmueller/AsciiDoc-MCP/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Installation
+Enables LLM interaction with large AsciiDoc/Markdown documentation projects through hierarchical, content-aware access via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+
+## Features
+
+- **Hierarchical Navigation** - Browse documentation structure with configurable depth
+- **Content Access** - Read sections, extract code blocks, tables, and other elements
+- **Full-Text Search** - Search across all indexed documentation content
+- **Document Manipulation** - Update sections and insert new content with optimistic locking
+- **Structure Validation** - Detect orphaned files and structural issues
+- **Multi-Format Support** - Works with both AsciiDoc and Markdown files
+
+## Quick Start
+
+### Installation
 
 ```bash
+# Clone the repository
+git clone https://github.com/rdmueller/AsciiDoc-MCP.git
+cd AsciiDoc-MCP
+
+# Install dependencies
 uv sync
 ```
 
-## Usage
+### Running the Server
 
 ```bash
-uv run python -m mcp_server --docs-root ./docs
+uv run python -m mcp_server --docs-root /path/to/your/docs
 ```
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/.config/claude-desktop/config.json` on Linux, `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "asciidoc-mcp": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory", "/path/to/AsciiDoc-MCP",
+        "python", "-m", "mcp_server",
+        "--docs-root", "/path/to/your/documentation"
+      ]
+    }
+  }
+}
+```
+
+## Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_structure` | Get hierarchical document structure with configurable depth |
+| `get_section` | Read content of a specific section by path |
+| `get_sections_at_level` | Get all sections at a specific nesting level |
+| `search` | Full-text search across documentation |
+| `get_elements` | Get code blocks, tables, images, and other elements |
+| `get_metadata` | Get project or section metadata (word count, timestamps) |
+| `validate_structure` | Validate documentation structure |
+| `update_section` | Update section content with optimistic locking |
+| `insert_content` | Insert new content before/after sections |
+
+For detailed tool documentation, see the [User Manual](docs/user-manual.md).
 
 ## Development
 
@@ -25,7 +81,21 @@ uv run pytest
 
 # Run linter
 uv run ruff check src tests
+
+# Format code
+uv run ruff format src tests
 ```
+
+## Architecture
+
+The server uses an in-memory index built from parsed documentation files at startup. Key components:
+
+- **Document Parsers** - Parse AsciiDoc (with include resolution) and Markdown
+- **Structure Index** - In-memory hierarchical index for fast lookups
+- **MCP Tools** - FastMCP-based tools for LLM interaction
+- **File Handler** - Atomic file operations with backup strategy
+
+For detailed architecture documentation, see [src/docs/arc42/](src/docs/arc42/).
 
 ## License
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,0 +1,465 @@
+# MCP Documentation Server - User Manual
+
+This manual provides detailed documentation for all available MCP tools, configuration options, and practical examples.
+
+## Table of Contents
+
+- [Configuration](#configuration)
+- [Navigation Tools](#navigation-tools)
+- [Content Access Tools](#content-access-tools)
+- [Search](#search)
+- [Document Manipulation](#document-manipulation)
+- [Meta-Information](#meta-information)
+- [Example Workflows](#example-workflows)
+
+---
+
+## Configuration
+
+### Claude Desktop
+
+Add the server to your Claude Desktop configuration:
+
+**Linux:** `~/.config/claude-desktop/config.json`
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "asciidoc-mcp": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory", "/path/to/AsciiDoc-MCP",
+        "python", "-m", "mcp_server",
+        "--docs-root", "/path/to/your/documentation"
+      ]
+    }
+  }
+}
+```
+
+### Amazon Q CLI / Kiro
+
+```json
+{
+  "mcpServers": {
+    "asciidoc-mcp": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory", "/path/to/AsciiDoc-MCP",
+        "python", "-m", "mcp_server",
+        "--docs-root", "/path/to/documentation"
+      ]
+    }
+  }
+}
+```
+
+### Command Line Options
+
+```bash
+uv run python -m mcp_server [OPTIONS]
+
+Options:
+  --docs-root PATH    Root directory containing documentation files
+  --help              Show help message
+```
+
+---
+
+## Navigation Tools
+
+### get_structure
+
+Get the hierarchical document structure.
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_depth` | int \| null | null | Maximum depth to return. Use 1 for top-level only. |
+
+**Returns:**
+```json
+{
+  "sections": [
+    {
+      "path": "introduction",
+      "title": "Introduction",
+      "level": 1,
+      "children": [
+        {
+          "path": "introduction.goals",
+          "title": "Goals",
+          "level": 2,
+          "children": []
+        }
+      ]
+    }
+  ],
+  "total_sections": 15
+}
+```
+
+**Example:**
+```
+get_structure(max_depth=2)
+```
+
+---
+
+### get_sections_at_level
+
+Get all sections at a specific nesting level.
+
+**Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `level` | int | Nesting level (1 = chapters, 2 = sections, etc.) |
+
+**Returns:**
+```json
+{
+  "level": 1,
+  "sections": [
+    {"path": "introduction", "title": "Introduction"},
+    {"path": "architecture", "title": "Architecture"}
+  ],
+  "count": 2
+}
+```
+
+---
+
+## Content Access Tools
+
+### get_section
+
+Read the content of a specific section.
+
+**Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Hierarchical path using dot notation (e.g., `introduction.goals`) |
+
+**Returns:**
+```json
+{
+  "path": "introduction.goals",
+  "title": "Goals",
+  "content": "== Goals\n\nThis section describes...",
+  "location": {
+    "file": "/docs/chapters/01_introduction.adoc",
+    "start_line": 15,
+    "end_line": 42
+  },
+  "format": "asciidoc"
+}
+```
+
+**Error Response (with suggestions):**
+```json
+{
+  "error": {
+    "code": "PATH_NOT_FOUND",
+    "message": "Section 'intro' not found",
+    "details": {
+      "requested_path": "intro",
+      "suggestions": ["introduction", "intro-page"]
+    }
+  }
+}
+```
+
+---
+
+### get_elements
+
+Get code blocks, tables, images, and other elements.
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `element_type` | string \| null | null | Filter by type: `code`, `table`, `image`, `diagram`, `list` |
+| `section_path` | string \| null | null | Filter by section path |
+
+**Returns:**
+```json
+{
+  "elements": [
+    {
+      "type": "code",
+      "location": {
+        "file": "/docs/example.adoc",
+        "line": 25
+      },
+      "preview": "[python] def hello()...",
+      "section_path": "examples.python"
+    }
+  ],
+  "count": 5
+}
+```
+
+**Example - Get all code blocks:**
+```
+get_elements(element_type="code")
+```
+
+**Example - Get elements in a specific section:**
+```
+get_elements(section_path="architecture.components")
+```
+
+---
+
+## Search
+
+### search
+
+Full-text search across documentation.
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | - | Search query (case-insensitive) |
+| `scope` | string \| null | null | Path prefix to limit search scope |
+| `max_results` | int | 50 | Maximum results to return |
+
+**Returns:**
+```json
+{
+  "query": "authentication",
+  "results": [
+    {
+      "path": "security.authentication",
+      "line": 45,
+      "context": "...implements OAuth2 authentication...",
+      "score": 0.95
+    }
+  ],
+  "total_results": 3
+}
+```
+
+**Example - Search in specific section:**
+```
+search(query="database", scope="architecture")
+```
+
+---
+
+## Document Manipulation
+
+### update_section
+
+Update the content of a section with optimistic locking support.
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | - | Section path using dot notation |
+| `content` | string | - | New section content |
+| `preserve_title` | bool | true | Keep original title if content doesn't include one |
+| `expected_hash` | string \| null | null | Hash for optimistic locking |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "introduction.goals",
+  "location": {
+    "file": "/docs/01_intro.adoc",
+    "line": 15
+  },
+  "previous_hash": "a1b2c3d4",
+  "new_hash": "e5f6g7h8"
+}
+```
+
+**Optimistic Locking Workflow:**
+1. Read section with `get_section` - note the content
+2. Compute or receive hash of current content
+3. Call `update_section` with `expected_hash`
+4. If hash mismatch, update fails with conflict error
+
+---
+
+### insert_content
+
+Insert content relative to a section.
+
+**Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Reference section path |
+| `position` | string | `before`, `after`, or `append` |
+| `content` | string | Content to insert |
+
+**Position Options:**
+- `before` - Insert before section start
+- `after` - Insert after section end
+- `append` - Append at end of section (before children)
+
+**Returns:**
+```json
+{
+  "success": true,
+  "inserted_at": {
+    "file": "/docs/chapter.adoc",
+    "line": 50
+  },
+  "previous_hash": "a1b2c3d4",
+  "new_hash": "e5f6g7h8"
+}
+```
+
+---
+
+## Meta-Information
+
+### get_metadata
+
+Get project or section metadata.
+
+**Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string \| null | null | Section path, or null for project metadata |
+
+**Project Metadata (no path):**
+```json
+{
+  "path": null,
+  "total_files": 15,
+  "total_sections": 87,
+  "total_words": 12450,
+  "last_modified": "2026-01-20T14:30:00+00:00",
+  "formats": ["asciidoc", "markdown"]
+}
+```
+
+**Section Metadata (with path):**
+```json
+{
+  "path": "architecture.decisions",
+  "title": "Architecture Decisions",
+  "file": "/docs/chapters/09_decisions.adoc",
+  "word_count": 2340,
+  "last_modified": "2026-01-19T10:15:00+00:00",
+  "subsection_count": 5
+}
+```
+
+---
+
+### validate_structure
+
+Validate the documentation structure.
+
+**Parameters:** None
+
+**Returns:**
+```json
+{
+  "valid": true,
+  "errors": [],
+  "warnings": [
+    {
+      "type": "orphaned_file",
+      "path": "chapters/unused.adoc",
+      "message": "File is not included in any document"
+    }
+  ],
+  "validation_time_ms": 120
+}
+```
+
+**Error Types:**
+- `unresolved_include` - Include directive points to missing file
+- `circular_include` - Circular include chain detected
+
+**Warning Types:**
+- `orphaned_file` - File exists but is not referenced
+
+---
+
+## Example Workflows
+
+### 1. Exploring a New Documentation Project
+
+```
+# Get high-level structure
+get_structure(max_depth=1)
+
+# Get project statistics
+get_metadata()
+
+# Browse chapters
+get_sections_at_level(level=1)
+
+# Read a specific chapter
+get_section(path="architecture")
+```
+
+### 2. Finding and Extracting Code Examples
+
+```
+# Find all code blocks
+get_elements(element_type="code")
+
+# Find code in specific section
+get_elements(element_type="code", section_path="examples")
+
+# Search for specific language
+search(query="python")
+```
+
+### 3. Updating Documentation
+
+```
+# Read current content
+get_section(path="api.endpoints")
+
+# Update with new content (preserving title)
+update_section(
+  path="api.endpoints",
+  content="New endpoint documentation...",
+  preserve_title=true
+)
+
+# Add a new section after existing one
+insert_content(
+  path="api.endpoints",
+  position="after",
+  content="== New Endpoint\n\nDescription..."
+)
+```
+
+### 4. Validating Documentation Quality
+
+```
+# Check for structural issues
+validate_structure()
+
+# Get word counts for sections
+get_metadata(path="introduction")
+get_metadata(path="architecture")
+```
+
+---
+
+## Path Format
+
+Paths use dot notation without document title prefix:
+
+| Level | Example Path |
+|-------|-------------|
+| Document root | `""` (empty) |
+| Chapter | `introduction` |
+| Section | `introduction.goals` |
+| Subsection | `introduction.goals.performance` |
+
+Paths are case-sensitive and derived from section titles (slugified).


### PR DESCRIPTION
## Summary
- Update README.md with features, badges, Quick Start guide, Claude Desktop config
- Create comprehensive User Manual (465 lines) with all MCP tool documentation

## Changes

### README.md
- Added CI/Python/License badges
- Features overview section
- Quick Start installation guide
- Claude Desktop configuration example
- MCP tools table (9 tools)
- Architecture overview
- Link to User Manual

### docs/user-manual.md (NEW)
- Configuration for Claude Desktop, Amazon Q/Kiro CLI
- All 9 MCP tools documented:
  - `get_structure`, `get_section`, `get_sections_at_level`
  - `search`, `get_elements`
  - `update_section`, `insert_content`
  - `get_metadata`, `validate_structure`
- 4 practical workflow examples
- Path format documentation

## Acceptance Criteria (from Issue #55)
- [x] README contains Quick-Start Guide
- [x] User Manual covers all tools
- [x] At least 3 practical examples (4 included)
- [x] Configuration guide for Claude Desktop
- [x] Configuration guide for Amazon Kiro-CLI

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)