### PR TITLE
fix: Resolve website documentation issues

### DIFF
--- a/src/docs/50-user-manual/10-installation.adoc
+++ b/src/docs/50-user-manual/10-installation.adoc
@@ -122,17 +122,6 @@ options:
                         Root directory containing documentation files
 ----
 
-**Check the CLI:**
-[source,bash]
-----
-uv run dacli --version
-----
-
-Expected output:
-----
-dacli, version 0.1.0
-----
-
 == Configuration
 
 === Claude Desktop

--- a/src/docs/50-user-manual/index.adoc
+++ b/src/docs/50-user-manual/index.adoc
@@ -19,4 +19,4 @@ Welcome to the MCP Documentation Server User Manual.
 
 The MCP Documentation Server enables LLM interaction with AsciiDoc and Markdown documentation projects through the Model Context Protocol (MCP).
 
-For architecture documentation, see the link:../arc42/arc42.adoc[arc42 documentation].
+For architecture documentation, see the link:../arc42/arc42.html[arc42 documentation].

--- a/src/docs/arc42/arc42.adoc
+++ b/src/docs/arc42/arc42.adoc
@@ -8,14 +8,8 @@
 // configure EN settings for asciidoc
 include::chapters/config.adoc[]
 
-= image:arc42-logo.png[arc42] Template
-:revnumber: {revnumber}
-:revdate: {revdate}
-:revremark: {revremark}
+= MCP Documentation Server - Architecture
 :toc-title: Table of Contents
-
-//additional style for arc42 help callouts
-include::chapters/../../../common/styles/arc42-help-style.adoc[]
 
 
 


### PR DESCRIPTION
## Summary

- Change arc42.adoc title from image macro to plain text (fixes navigation sidebar display)
- Remove unresolved arc42 template variables (revnumber, revdate, revremark)
- Remove unresolved include directive for arc42-help-style
- Fix broken link in user-manual (arc42.adoc → arc42.html)
- Remove duplicate "Check the CLI" section in installation guide

## Test plan

- [ ] Verify website builds successfully
- [ ] Check arc42 navigation shows proper title instead of image macro text
- [ ] Confirm no unresolved variables in rendered arc42 page
- [ ] Test link from user-manual to arc42 documentation works
- [ ] Verify installation guide has no duplicate sections

Fixes #78, #79, #80, #81, #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)