### PR TITLE
feat: Expose gitignore and hidden directory options (Issue #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ uv run dacli search "authentication" --max-results 10
 
 # Validate structure
 uv run dacli validate
+
+# Include gitignored files
+uv run dacli --docs-root /path/to/docs --no-gitignore structure
+
+# Include hidden directories
+uv run dacli --docs-root /path/to/docs --include-hidden structure
 ```
 
 All commands output text by default for human readability. Use `--format json` or `--format yaml` for machine-parseable output, and `--pretty` for formatted JSON output.
@@ -57,6 +63,12 @@ For full CLI documentation, see [06_cli_specification.adoc](src/docs/spec/06_cli
 
 ```bash
 uv run dacli-mcp --docs-root /path/to/your/docs
+
+# Include gitignored files
+uv run dacli-mcp --docs-root /path/to/your/docs --no-gitignore
+
+# Include hidden directories  
+uv run dacli-mcp --docs-root /path/to/your/docs --include-hidden
 ```
 
 #### Claude Desktop Configuration

--- a/src/dacli/main.py
+++ b/src/dacli/main.py
@@ -49,6 +49,18 @@ def create_parser() -> argparse.ArgumentParser:
         help="Root directory containing documentation files. "
         "Can also be set via PROJECT_PATH environment variable.",
     )
+    parser.add_argument(
+        "--no-gitignore",
+        action="store_true",
+        default=False,
+        help="Include files that would normally be excluded by .gitignore patterns.",
+    )
+    parser.add_argument(
+        "--include-hidden",
+        action="store_true",
+        default=False,
+        help="Include files in hidden directories (starting with '.').",
+    )
     return parser
 
 
@@ -96,7 +108,11 @@ def main() -> int:
         return 1
 
     # Create and run MCP server
-    mcp = create_mcp_server(docs_root=docs_root)
+    mcp = create_mcp_server(
+        docs_root=docs_root,
+        respect_gitignore=not args.no_gitignore,
+        include_hidden=args.include_hidden,
+    )
 
     # Run with stdio transport (default for MCP)
     mcp.run()

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -17,6 +17,9 @@ Options:
   --docs-root PATH    Dokumentations-Wurzelverzeichnis (default: $PROJECT_PATH oder cwd)
   --format FORMAT     Ausgabeformat: text (default), json, yaml
   --pretty            Formatierte Ausgabe für Menschen
+  --quiet, -q         Unterdrückt Warnmeldungen
+  --no-gitignore      Dateien einbeziehen, die normalerweise durch .gitignore-Muster ausgeschlossen würden
+  --include-hidden    Dateien in versteckten Verzeichnissen (beginnend mit '.') einbeziehen
   --version           Zeigt Version
   --help              Zeigt Hilfe
 ----


### PR DESCRIPTION
## Summary

- Add `--no-gitignore` flag to include files matching .gitignore patterns
- Add `--include-hidden` flag to include files in hidden directories (starting with '.')
- Both options available in CLI (`dacli`) and MCP server (`dacli-mcp`)

Closes #91

## Changes

- **src/dacli/mcp_app.py**: Added `respect_gitignore` and `include_hidden` parameters to `_build_index` and `create_mcp_server` functions
- **src/dacli/cli.py**: Added CLI flags and updated `CliContext` to pass options to index building
- **src/dacli/main.py**: Added MCP server CLI arguments
- **tests/test_cli.py**: Added `TestCliGitignoreOptions` test class with 5 tests
- **README.md**: Documented new options with usage examples
- **src/docs/spec/06_cli_specification.adoc**: Updated specification with new options

## Test plan

- [x] All 334 tests pass
- [x] Verified `--no-gitignore` includes files that would be excluded by .gitignore
- [x] Verified `--include-hidden` includes files in hidden directories
- [x] Verified both options work together

🤖 Generated with [Claude Code](https://claude.com/claude-code)