### PR TITLE
docs: Redesign landing page with Jobs-to-be-Done approach (Issue #98)

### DIFF
--- a/docToolchainConfig.groovy
+++ b/docToolchainConfig.groovy
@@ -93,7 +93,7 @@ microsite.with {
     siteFolder = '../site'
 
     // the title of the microsite, displayed in the upper left corner
-    title = 'MCP Documentation Server'
+    title = 'dacli'
     // the next items configure some links in the footer
     //
     // contact eMail
@@ -107,7 +107,7 @@ microsite.with {
     footerSO = ''
     //
     // Github Repository
-    footerGithub = 'https://github.com/rdmueller/AsciiDoc-MCP'
+    footerGithub = 'https://github.com/docToolchain/dacli'
     //
     // Slack Channel
     footerSlack = ''
@@ -117,16 +117,16 @@ microsite.with {
     footerText = '<small class="text-white">built with <a href="https://doctoolchain.org">docToolchain</a> and <a href="https://jbake.org">jBake</a> <br /> theme: <a href="https://www.docsy.dev/">docsy</a></small>'
     //
     // site title if no other title is given
-    title = 'MCP Documentation Server'
+    title = 'dacli'
     //
     // the url to create an issue in github
     // Example: https://github.com/docToolchain/docToolchain/issues/new
-    issueUrl = 'https://github.com/rdmueller/AsciiDoc-MCP/issues/new'
+    issueUrl = 'https://github.com/docToolchain/dacli/issues/new'
     //
     // the base url for code files in github
     // Example: https://github.com/doctoolchain/doctoolchain/edit/master/src/docs
     branch = System.getenv("DTC_PROJECT_BRANCH")?:'-'
-    gitRepoUrl = 'https://github.com/rdmueller/AsciiDoc-MCP/edit/main/src/docs'
+    gitRepoUrl = 'https://github.com/docToolchain/dacli/edit/main/src/docs'
 
     //
     // the location of the landing page

--- a/src/site/doc/landingpage.gsp
+++ b/src/site/doc/landingpage.gsp
@@ -1,88 +1,150 @@
 <div class="row flex-xl-nowrap">
     <main class="col-12 col-md-12 col-xl-12 pl-md-12" role="main">
-        <div class="bg-light p-5 rounded">
-            <h1>MCP Documentation Server</h1>
-            <p class="lead">
-                Enable LLM interaction with large AsciiDoc and Markdown documentation projects through hierarchical, content-aware access via the Model Context Protocol (MCP).
+        <!-- Hero Section with JTBD Focus -->
+        <div class="p-5 rounded" style="background: linear-gradient(135deg, #1a365d 0%, #2d5a87 100%); color: white; margin-bottom: 2rem;">
+            <h1 style="font-size: 2.5rem; font-weight: 700;">dacli</h1>
+            <p class="lead" style="font-size: 1.4rem; opacity: 0.95;">
+                Let your AI understand your documentation.
             </p>
-            <p>
-                The MCP Documentation Server provides a powerful bridge between Large Language Models and your documentation.
-                It parses your docs, builds an in-memory index, and exposes 9 MCP tools for navigation, search, and manipulation.
+            <p style="font-size: 1.1rem; opacity: 0.85; max-width: 700px;">
+                Large documentation projects are hard for LLMs to navigate. dacli gives AI assistants structured access to your AsciiDoc and Markdown docs - so they can find, read, and update exactly what they need.
             </p>
-            <p>
-                <a href="https://github.com/rdmueller/AsciiDoc-MCP" class="btn btn-primary">View on GitHub</a>
-                <a href="arc42/arc42.html" class="btn btn-outline-secondary">Architecture Documentation</a>
+            <p style="margin-top: 1.5rem;">
+                <a href="https://github.com/docToolchain/dacli" class="btn btn-light btn-lg" style="font-weight: 600;">
+                    Get Started
+                </a>
+                <a href="50-user-manual/index.html" class="btn btn-outline-light btn-lg" style="margin-left: 0.5rem;">
+                    Documentation
+                </a>
             </p>
         </div>
 
-        <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
-            <div class="col">
-                <div class="card mb-4 shadow-sm">
-                    <div class="card-header">
-                        <h4 class="my-0 fw-normal">Hierarchical Navigation</h4>
-                    </div>
+        <!-- Jobs to be Done Section -->
+        <h2 style="text-align: center; margin-bottom: 2rem; color: #1a365d;">What can you accomplish?</h2>
+
+        <div class="row row-cols-1 row-cols-md-2 mb-4">
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
                     <div class="card-body">
-                        Browse documentation structure with configurable depth. Navigate chapters, sections, and subsections using intuitive dot-notation paths.
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128269;</span>
+                            Find information instantly
+                        </h4>
+                        <p class="card-text">
+                            "Where is the authentication logic documented?"<br>
+                            Your AI assistant searches across all your docs and finds the exact section - no more manual searching through hundreds of files.
+                        </p>
                     </div>
                 </div>
             </div>
-            <div class="col">
-                <div class="card mb-4 shadow-sm">
-                    <div class="card-header">
-                        <h4 class="my-0 fw-normal">Full-Text Search</h4>
-                    </div>
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
                     <div class="card-body">
-                        Search across all indexed documentation content. Find relevant sections quickly with scoped searches and relevance scoring.
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128506;</span>
+                            Navigate complex structures
+                        </h4>
+                        <p class="card-text">
+                            "Show me the architecture overview."<br>
+                            dacli understands your document hierarchy. AI can browse chapters, sections, and subsections - just like a human would.
+                        </p>
                     </div>
                 </div>
             </div>
-            <div class="col">
-                <div class="card mb-4 shadow-sm">
-                    <div class="card-header">
-                        <h4 class="my-0 fw-normal">Document Manipulation</h4>
-                    </div>
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
                     <div class="card-body">
-                        Update sections and insert new content with optimistic locking support. Validate documentation structure for orphaned files and broken includes.
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#9997;</span>
+                            Keep docs up-to-date
+                        </h4>
+                        <p class="card-text">
+                            "Update the API documentation for the new endpoint."<br>
+                            AI can read existing docs and make targeted updates - with optimistic locking to prevent conflicts.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
+                    <div class="card-body">
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128640;</span>
+                            Works with your tools
+                        </h4>
+                        <p class="card-text">
+                            Use as an MCP server with Claude Desktop, Cursor, or any MCP-compatible AI. Or use the CLI for LLMs that support shell commands.
+                        </p>
                     </div>
                 </div>
             </div>
         </div>
 
-        <div class="row row-cols-1 row-cols-md-2 mb-3">
-            <div class="col">
-                <div class="card mb-4 shadow-sm">
-                    <div class="card-header">
-                        <h4 class="my-0 fw-normal">Quick Start</h4>
-                    </div>
-                    <div class="card-body">
-                        <pre><code># Clone and install
-git clone https://github.com/rdmueller/AsciiDoc-MCP.git
-cd AsciiDoc-MCP
-uv sync
-
-# Run the server
-uv run python -m mcp_server --docs-root /path/to/docs</code></pre>
+        <!-- How it works -->
+        <div class="bg-light p-4 rounded mb-4">
+            <h3 style="color: #1a365d; margin-bottom: 1.5rem;">Two ways to connect</h3>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div class="card h-100">
+                        <div class="card-header" style="background-color: #1a365d; color: white;">
+                            <h5 class="mb-0">MCP Server</h5>
+                            <small>For Claude Desktop, Cursor & MCP clients</small>
+                        </div>
+                        <div class="card-body">
+                            <pre style="background: #f8f9fa; padding: 1rem; border-radius: 4px; font-size: 0.85rem;"><code># Add to your MCP client config
+{
+  "mcpServers": {
+    "dacli": {
+      "command": "uvx",
+      "args": ["dacli-mcp",
+        "--docs-root", "/path/to/docs"]
+    }
+  }
+}</code></pre>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="col">
-                <div class="card mb-4 shadow-sm">
-                    <div class="card-header">
-                        <h4 class="my-0 fw-normal">CLI for LLMs</h4>
-                    </div>
-                    <div class="card-body">
-                        <pre><code># Install globally
-uv tool install .
-
-# Get document structure
-dacli --docs-root /path/to/docs structure
+                <div class="col-md-6 mb-3">
+                    <div class="card h-100">
+                        <div class="card-header" style="background-color: #2d5a87; color: white;">
+                            <h5 class="mb-0">CLI Tool</h5>
+                            <small>For LLMs with shell access</small>
+                        </div>
+                        <div class="card-body">
+                            <pre style="background: #f8f9fa; padding: 1rem; border-radius: 4px; font-size: 0.85rem;"><code># Install and use
+uvx dacli --docs-root ./docs structure
 
 # Search documentation
-dacli search "authentication"</code></pre>
+uvx dacli search "authentication"
+
+# Read a section
+uvx dacli section api.endpoints</code></pre>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </main>
 
+        <!-- Supported Formats -->
+        <div class="text-center mb-4 p-4">
+            <h4 style="color: #1a365d;">Supports your documentation format</h4>
+            <p class="text-muted">
+                <span style="font-size: 1.2rem; margin: 0 1rem;">&#128196; AsciiDoc</span>
+                <span style="font-size: 1.2rem; margin: 0 1rem;">&#128221; Markdown</span>
+            </p>
+            <p class="text-muted">
+                Including nested includes, code blocks, tables, images, and PlantUML diagrams.
+            </p>
+        </div>
+
+        <!-- Call to Action -->
+        <div class="text-center p-4 rounded" style="background-color: #f0f7ff;">
+            <h3 style="color: #1a365d;">Ready to give your AI documentation superpowers?</h3>
+            <p class="text-muted mb-3">Part of the <a href="https://doctoolchain.org" style="color: #2d5a87;">docToolchain</a> ecosystem.</p>
+            <p>
+                <a href="https://github.com/docToolchain/dacli" class="btn btn-primary btn-lg">View on GitHub</a>
+                <a href="arc42/chapters/01_introduction_and_goals.html" class="btn btn-outline-secondary btn-lg">Architecture Docs</a>
+            </p>
+        </div>
+    </main>
 </div>


### PR DESCRIPTION
## Summary

Redesigns the landing page using the Jobs-to-be-Done (JTBD) framework to focus on what users want to accomplish rather than listing features.

### Changes

- **Hero Section**: New gradient design with clear value proposition "Let your AI understand your documentation"
- **JTBD Cards**: Four user-focused cards answering "What can you accomplish?":
  - Find information instantly
  - Navigate complex structures
  - Keep docs up-to-date
  - Works with your tools
- **Integration Examples**: Updated code examples showing both MCP server and CLI usage with modern `uvx` command
- **Branding Update**: Changed from "MCP Documentation Server" to "dacli"
- **URL Fixes**: Updated all GitHub URLs from `rdmueller/AsciiDoc-MCP` to `docToolchain/dacli`
- **Visual Design**: Modern gradient hero, accent-colored card borders, better typography

### Before/After

**Before**: Feature-focused landing page listing technical capabilities
**After**: User-focused landing page addressing jobs users want to accomplish

## Test plan

- [ ] Build the site locally and verify landing page renders correctly
- [ ] Check all links work (GitHub, documentation)
- [ ] Verify responsive design on mobile

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)