### PR TITLE
feat(cli): Replace --quiet with --verbose for LLM-friendly defaults (Issue #100)

### DIFF
--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -50,19 +50,20 @@ class CliContext:
         docs_root: Path,
         output_format: str,
         pretty: bool,
-        quiet: bool = False,
+        verbose: bool = False,
         respect_gitignore: bool = True,
         include_hidden: bool = False,
     ):
         self.docs_root = docs_root
         self.output_format = output_format
         self.pretty = pretty
-        self.quiet = quiet
+        self.verbose = verbose
         self.respect_gitignore = respect_gitignore
         self.include_hidden = include_hidden
 
-        # Configure logging level based on quiet flag
-        if quiet:
+        # Configure logging level based on verbose flag
+        # Default is quiet (ERROR only), verbose enables WARNING
+        if not verbose:
             logging.getLogger().setLevel(logging.ERROR)
 
         self.index = StructureIndex()
@@ -141,10 +142,10 @@ pass_context = click.make_pass_decorator(CliContext)
     help="Pretty-print output for human readability",
 )
 @click.option(
-    "--quiet", "-q",
+    "--verbose", "-v",
     is_flag=True,
     default=False,
-    help="Suppress warning messages (errors are still shown)",
+    help="Show warning messages (default: only errors are shown)",
 )
 @click.option(
     "--no-gitignore",
@@ -165,7 +166,7 @@ def cli(
     docs_root: Path,
     output_format: str,
     pretty: bool,
-    quiet: bool,
+    verbose: bool,
     no_gitignore: bool,
     include_hidden: bool,
 ):
@@ -178,7 +179,7 @@ def cli(
         docs_root,
         output_format,
         pretty,
-        quiet,
+        verbose,
         respect_gitignore=not no_gitignore,
         include_hidden=include_hidden,
     )

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -17,7 +17,7 @@ Options:
   --docs-root PATH    Documentation root directory (default: $PROJECT_PATH or cwd)
   --format FORMAT     Output format: text (default), json, yaml
   --pretty            Formatted output for humans
-  --quiet, -q         Suppress warning messages
+  --verbose, -v       Show warning messages (default: only errors shown)
   --no-gitignore      Include files that would normally be excluded by .gitignore patterns
   --include-hidden    Include files in hidden directories (starting with '.')
   --version           Show version


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Inverts warning behavior to make dacli more LLM-friendly.

### Before (problematic for LLMs)
```bash
# Warnings flood output - LLM needs to know to add -q
dacli search "MCP" --format json
# Output: 100+ warning lines + JSON

# LLM must learn this workaround
dacli -q --format json search "MCP"
```

### After (LLM-friendly)
```bash
# Default is clean output - just works
dacli --format json search "MCP"
# Output: clean JSON

# Use -v only when debugging
dacli -v --format json search "MCP"
```

## Changes

| Before | After |
|--------|-------|
| `--quiet, -q` (opt-in to suppress warnings) | `--verbose, -v` (opt-in to show warnings) |
| Warnings shown by default | Warnings suppressed by default |
| LLMs need `-q` for clean output | LLMs get clean output by default |

## Technical Details

- JSON output is JSONL-compatible (single line without `--pretty`)
- Errors are always shown regardless of `--verbose` flag
- Logging level defaults to ERROR, verbose enables WARNING

## Test plan

- [x] All 334 tests pass
- [x] `dacli --format json search "test"` produces clean JSON
- [x] `dacli -v --format json search "test"` shows warnings if any

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)