### PR TITLE
fix: Include README.md and CLAUDE.md in documentation indexing

### DIFF
--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -627,8 +627,7 @@ def validate(ctx: CliContext):
     for adoc_file in find_doc_files(ctx.docs_root, "*.adoc"):
         all_doc_files.add(adoc_file.resolve())
     for md_file in find_doc_files(ctx.docs_root, "*.md"):
-        if md_file.name not in ("CLAUDE.md", "README.md"):
-            all_doc_files.add(md_file.resolve())
+        all_doc_files.add(md_file.resolve())
 
     indexed_resolved = {f.resolve() for f in indexed_files}
     for doc_file in all_doc_files:

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -637,8 +637,7 @@ def create_mcp_server(
         for adoc_file in find_doc_files(docs_root, "*.adoc"):
             all_doc_files.add(adoc_file.resolve())
         for md_file in find_doc_files(docs_root, "*.md"):
-            if md_file.name not in ("CLAUDE.md", "README.md"):
-                all_doc_files.add(md_file.resolve())
+            all_doc_files.add(md_file.resolve())
 
         # Check for orphaned files (files not indexed)
         indexed_resolved = {f.resolve() for f in indexed_files}
@@ -702,9 +701,6 @@ def _build_index(
     for md_file in find_doc_files(
         docs_root, "*.md", respect_gitignore=respect_gitignore, include_hidden=include_hidden
     ):
-        # Skip common non-doc files
-        if md_file.name in ("CLAUDE.md", "README.md"):
-            continue
         try:
             md_doc = markdown_parser.parse_file(md_file)
             # Convert MarkdownDocument to Document

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -756,6 +756,78 @@ class TestCliHelpImprovements:
         assert "Examples:" in result.output or "dacli" in result.output
 
 
+class TestCliReadmeInclusion:
+    """Test that README.md and CLAUDE.md are included in indexing (Issue #107)."""
+
+    def test_readme_is_indexed_and_searchable(self, tmp_path):
+        """README.md should be indexed and searchable."""
+        from dacli.cli import cli
+
+        # Create README.md with searchable content
+        readme = tmp_path / "README.md"
+        readme.write_text("""# Project Documentation
+
+## Authentication
+
+This section covers authentication mechanisms.
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(tmp_path), "--format", "json", "search", "authentication"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total_results"] > 0, "README.md content should be searchable"
+
+    def test_claude_md_is_indexed_and_searchable(self, tmp_path):
+        """CLAUDE.md should be indexed and searchable."""
+        from dacli.cli import cli
+
+        # Create CLAUDE.md with searchable content
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("""# Claude Instructions
+
+## Configuration
+
+Special configuration for Claude assistant.
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(tmp_path), "--format", "json", "search", "configuration"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total_results"] > 0, "CLAUDE.md content should be searchable"
+
+    def test_readme_appears_in_structure(self, tmp_path):
+        """README.md should appear in document structure."""
+        from dacli.cli import cli
+
+        readme = tmp_path / "README.md"
+        readme.write_text("""# My Project
+
+## Overview
+
+Project overview.
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(tmp_path), "--format", "json", "structure"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total_sections"] > 0, "README.md sections should be in structure"
+
+
 class TestCliInsertCommand:
     """Test the 'insert' command."""
 


### PR DESCRIPTION
## Summary

Previously README.md and CLAUDE.md were excluded from documentation indexing. Users expect all .md files to be searchable.

## Changes

- Remove exclusion filter in `_build_index()` (mcp_app.py)
- Remove exclusion filter in `validate_structure` (CLI and MCP)
- Add 3 tests for README.md and CLAUDE.md inclusion

## Test plan

- [x] README.md content is searchable
- [x] CLAUDE.md content is searchable  
- [x] README.md appears in document structure
- [x] All 359 existing tests pass

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)