### PR TITLE
fix: Pin pydocket<0.17 to fix fastmcp compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "fastmcp>=2.14.0,<3",
     "pathspec>=1.0.3",
+    "pydocket<0.17",  # Pin to avoid breaking change in 0.17 (fastmcp compatibility)
     "pyyaml>=6.0",
     "uvicorn>=0.30.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -305,6 +305,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "pathspec" },
+    { name = "pydocket" },
     { name = "pyyaml" },
     { name = "uvicorn" },
 ]
@@ -323,6 +324,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.14.0,<3" },
     { name = "pathspec", specifier = ">=1.0.3" },
+    { name = "pydocket", specifier = "<0.17" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-html", marker = "extra == 'dev'", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary
- Pin pydocket to versions below 0.17 to fix fastmcp compatibility issue

## Problem
pydocket 0.17 renamed `_Depends` to `Depends`, which breaks fastmcp's import statement:
```
ImportError: cannot import name '_Depends' from 'docket.dependencies'
```

This causes `dacli --version` (and other commands) to fail after installing with `uv tool install`.

## Solution
Added version constraint `pydocket<0.17` to dependencies until fastmcp updates its dependency handling.

## Test plan
- [x] All 359 tests pass
- [x] `uv tool install . --force && dacli --version` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)