### PR TITLE
docs: Align arc42 architecture documentation with actual implementation

### DIFF
--- a/src/docs/50-user-manual/20-mcp-tools.adoc
+++ b/src/docs/50-user-manual/20-mcp-tools.adoc
@@ -4,7 +4,7 @@
 
 == Overview
 
-The MCP Documentation Server provides 9 tools for interacting with documentation projects via the Model Context Protocol. These tools enable LLMs to navigate, read, search, and modify documentation.
+dacli provides 9 MCP tools for interacting with documentation projects via the Model Context Protocol. These tools enable LLMs to navigate, read, search, and modify documentation.
 
 == Navigation Tools
 

--- a/src/docs/50-user-manual/50-tutorial.adoc
+++ b/src/docs/50-user-manual/50-tutorial.adoc
@@ -16,7 +16,7 @@ The examples in this tutorial serve to illustrate the tool's functionality and o
 
 == Prerequisites
 
-The CLI is included with the MCP Documentation Server. Install it globally:
+The CLI is included with dacli. Install it globally:
 
 [source,bash]
 ----

--- a/src/docs/50-user-manual/index.adoc
+++ b/src/docs/50-user-manual/index.adoc
@@ -1,7 +1,7 @@
 = User Manual
 :toc:
 
-Welcome to the MCP Documentation Server User Manual.
+Welcome to the dacli User Manual.
 
 == Contents
 
@@ -17,6 +17,6 @@ Welcome to the MCP Documentation Server User Manual.
 
 == About
 
-The MCP Documentation Server enables LLM interaction with AsciiDoc and Markdown documentation projects through the Model Context Protocol (MCP).
+dacli enables LLM interaction with AsciiDoc and Markdown documentation projects through the Model Context Protocol (MCP). It provides both a CLI tool for direct use and an MCP server for LLM integration.
 
 For architecture documentation, see the link:../arc42/arc42.html[arc42 documentation].

--- a/src/docs/arc42/arc42.adoc
+++ b/src/docs/arc42/arc42.adoc
@@ -8,7 +8,7 @@
 // configure EN settings for asciidoc
 include::chapters/config.adoc[]
 
-= MCP Documentation Server - Architecture
+= dacli - Architecture Documentation
 :toc-title: Table of Contents
 
 

--- a/src/docs/arc42/chapters/01_introduction_and_goals.adoc
+++ b/src/docs/arc42/chapters/01_introduction_and_goals.adoc
@@ -20,7 +20,7 @@ Large Language Models (LLMs) face significant challenges when interacting with e
 *   **Inefficient Access**: Reading entire files is token-inefficient when only small sections are needed.
 *   **Difficult Manipulation**: Modifying specific parts of a document is cumbersome and error-prone.
 
-The **MCP Documentation Server** aims to solve these problems by providing a structured, content-aware API for interacting with AsciiDoc and Markdown projects. This enables efficient navigation, reading, and modification of complex documentation.
+**dacli** (Documentation Access CLI) aims to solve these problems by providing structured, content-aware tools for interacting with AsciiDoc and Markdown projects. Available as both a CLI tool and MCP server, it enables efficient navigation, reading, and modification of complex documentation.
 
 === Quality Goals
 
@@ -38,15 +38,15 @@ The architecture will prioritize the following key quality goals, derived from t
 
 === Stakeholders
 
-The primary stakeholders of the MCP Documentation Server are:
+The primary stakeholders of dacli are:
 
 .Stakeholders
 [cols="1,2,2"]
 |===
 | Role/Name | Contact | Expectations
-| **Software Developer** | Development Team | Uses the server to analyze and maintain code documentation with LLM assistance.
-| **Software Architect** | Architecture Team | Uses the server to manage and update large-scale architecture documents (e.g., arc42) with LLMs.
-| **Documentation Engineer** | Documentation Team | Manages complex documentation projects, relying on the server for efficient navigation and maintenance.
+| **Software Developer** | Development Team | Uses dacli to analyze and maintain code documentation with LLM assistance.
+| **Software Architect** | Architecture Team | Uses dacli to manage and update large-scale architecture documents (e.g., arc42) with LLMs.
+| **Documentation Engineer** | Documentation Team | Manages complex documentation projects, relying on dacli for efficient navigation and maintenance.
 |===
 
 [plantuml, stakeholder-overview, svg]
@@ -60,7 +60,7 @@ actor "Software Developer" as Dev
 actor "Software Architect" as Arch
 actor "Documentation Engineer" as DocEng
 
-rectangle "MCP Documentation Server" as Server {
+rectangle "dacli" as Server {
   usecase "Analyze & Maintain Docs" as UC1
   usecase "Update Architecture" as UC2
   usecase "Manage Projects" as UC3

--- a/src/docs/arc42/chapters/02_architecture_constraints.adoc
+++ b/src/docs/arc42/chapters/02_architecture_constraints.adoc
@@ -11,7 +11,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-architecture-constraints]]
 == Architecture Constraints
 
-This chapter outlines the constraints that shape the architecture of the MCP Documentation Server.
+This chapter outlines the constraints that shape the architecture of dacli.
 
 === Technical Constraints
 
@@ -36,7 +36,7 @@ The system must adhere to the following technical constraints, derived directly 
 | Constraint | Description
 | **Workflow Integration** | The solution must integrate seamlessly into existing developer workflows without imposing significant process changes.
 | **No External Services** | The system must be self-contained and not rely on any external or third-party services for its core functionality.
-| **Phased Development** | The project will be developed in phases (Core Engine, MCP Integration, Web Interface), requiring a modular architecture that supports incremental delivery.
+| **Phased Development** | The project is developed in phases (Core Engine, MCP Integration, CLI), requiring a modular architecture that supports incremental delivery.
 |===
 
 === Conventions

--- a/src/docs/arc42/chapters/03_context_and_scope.adoc
+++ b/src/docs/arc42/chapters/03_context_and_scope.adoc
@@ -15,7 +15,7 @@ This chapter describes the system's boundaries, its users, and its interactions 
 
 === Business Context
 
-From a business perspective, the MCP Documentation Server acts as a specialized middleware that enables technical users to interact with documentation projects more effectively. It abstracts away the complexity of file-based document structures.
+From a business perspective, dacli acts as a specialized middleware that enables technical users to interact with documentation projects more effectively. It abstracts away the complexity of file-based document structures and provides both a CLI for direct use and an MCP server for LLM integration.
 
 [plantuml, business-context, svg]
 ----
@@ -23,7 +23,7 @@ From a business perspective, the MCP Documentation Server acts as a specialized 
 !include <C4/C4_Context>
 LAYOUT_WITH_LEGEND()
 
-title Business Context for MCP Documentation Server
+title Business Context for dacli
 
 Person(developer, "Software Developer / Architect", "Works on code and documentation.")
 Person(doc_eng, "Documentation Engineer", "Manages large documentation projects.")
@@ -40,7 +40,7 @@ Rel_Back(dacli, doc_project, "Reads from and writes to")
 
 === Technical Context
 
-On a technical level, the system is accessed by an MCP-compliant client. It interacts directly with the file system to read documentation source files and write back modifications. It is also aware of the version control system (Git) to ensure workflow compatibility.
+On a technical level, the MCP server is spawned as a subprocess by an MCP-compliant client and communicates via stdio (standard input/output). The CLI tool can be invoked directly from the shell. Both interfaces interact directly with the file system to read documentation source files and write back modifications.
 
 [plantuml, technical-context, svg]
 ----
@@ -48,16 +48,18 @@ On a technical level, the system is accessed by an MCP-compliant client. It inte
 !include <C4/C4_Context>
 LAYOUT_WITH_LEGEND()
 
-title Technical Context for MCP Documentation Server
+title Technical Context for dacli
 
-System(mcp_client, "MCP Client (e.g., LLM Agent)", "Initiates requests to view or modify documentation.")
+System(mcp_client, "MCP Client (e.g., Claude Desktop)", "Spawns dacli-mcp and sends tool calls.")
+Person(user, "Developer", "Invokes dacli CLI directly.")
 
-System(dacli, "dacli", "The system being built.")
+System(dacli, "dacli", "CLI tool and MCP server.")
 
 System_Ext(file_system, "File System", "Stores the AsciiDoc/Markdown source files.")
 System_Ext(git, "Git Version Control", "Tracks changes to the documentation files.")
 
-Rel(mcp_client, dacli, "Sends requests to", "MCP Protocol over HTTPS")
+Rel(mcp_client, dacli, "Spawns and communicates via", "stdio (MCP Protocol)")
+Rel(user, dacli, "Executes commands", "Shell")
 Rel(dacli, file_system, "Reads/Writes files", "File System API")
 Rel(dacli, git, "Is compatible with", "Standard Git commands")
 @enduml

--- a/src/docs/arc42/chapters/04_solution_strategy.adoc
+++ b/src/docs/arc42/chapters/04_solution_strategy.adoc
@@ -29,12 +29,11 @@ To implement this strategy, the following technology stack is proposed. The choi
 [cols="1,2,3"]
 |===
 | Component | Technology | Justification
-| **Language** | **Python 3.12+** | Excellent for text processing, large standard library, strong community support, and mature libraries for parsing and web development.
+| **Language** | **Python 3.12+** | Excellent for text processing, large standard library, strong community support, and mature libraries for parsing.
 | **Package Manager** | **uv** | Ultra-fast Python package installer and resolver. Provides deterministic builds via `uv.lock`, faster dependency resolution than pip/poetry, and integrated virtual environment management.
-| **Web Server / API** | **FastAPI** | Provides a high-performance, MCP-compliant web server with automatic data validation and API documentation, directly supporting **Usability** (USAB-1, USAB-2).
-| **MCP SDK** | **mcp[cli]** | Official MCP SDK for Python to ensure full protocol compliance.
-| **Document Parsing** | **Custom Parser Logic** | A custom parser will be developed to handle AsciiDoc/Markdown specifics, especially the critical requirement of resolving includes and tracking line numbers accurately. Off-the-shelf libraries often lack the required granularity. This directly addresses the risk of **Format Variations**.
-| **Diff Engine** | **difflib** | Python's standard library for generating diffs, sufficient for providing real-time feedback in the web UI (**Usability**, USAB-3).
+| **MCP Framework** | **FastMCP** | High-level framework for building MCP servers in Python. Simplifies tool registration, handles MCP protocol details, and provides stdio transport.
+| **CLI Framework** | **Click** | Mature Python CLI framework for building the `dacli` command-line interface.
+| **Document Parsing** | **Custom Parser Logic** | Custom parsers handle AsciiDoc/Markdown specifics, especially resolving includes and tracking line numbers accurately. Off-the-shelf libraries often lack the required granularity. This directly addresses the risk of **Format Variations**.
 |===
 
 === Development Environment Setup
@@ -71,6 +70,7 @@ The architectural strategy directly addresses the top quality goals defined in C
 | Strategy | Quality Goal Addressed | How it is achieved
 | **In-Memory Structure Index** | **Performance** (PERF-1, PERF-2) | Read operations query the fast in-memory index for file locations instead of parsing files on every request.
 | **Atomic Write-Through Cache** | **Reliability** (REL-1, REL-3) | A File System Handler component implements atomic writes by using temporary files and backups. This prevents file corruption.
-| **MCP-Compliant API (FastAPI)** | **Usability** (USAB-1) | FastAPI's strict schema validation and automatic documentation ensures the API adheres to the defined protocol.
+| **MCP-Compliant Tools (FastMCP)** | **Usability** (USAB-1) | FastMCP handles MCP protocol compliance, tool registration, and stdio transport. Tools are strongly typed with clear parameter definitions.
+| **Dual Interface (CLI + MCP)** | **Usability** (USAB-2) | Both CLI (for direct use) and MCP server (for LLM integration) share the same core logic, ensuring consistent behavior.
 | **Stateless, File-Based Design** | **Scalability** (SCAL-1) & **Reliability** | By keeping the server stateless, scaling becomes simpler (less state to manage). It also improves reliability as there is no complex database state to corrupt or manage.
 |===

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -15,7 +15,7 @@ This chapter describes the static decomposition of the system into its key build
 
 === Level 2: System Containers
 
-The MCP Documentation Server system is composed of two main containers: a web-based user interface and the back-end API server. The file system acts as the system's database.
+The dacli system provides two interfaces: a CLI tool for direct command-line usage and an MCP server for LLM integration. The file system acts as the system's database.
 
 [plantuml, container-overview, svg]
 ----
@@ -24,27 +24,27 @@ The MCP Documentation Server system is composed of two main containers: a web-ba
 LAYOUT_TOP_DOWN()
 SHOW_LEGEND()
 
-title Container diagram for MCP Documentation Server
+title Container diagram for dacli
 
-Person(user, "Developer / Architect", "Uses the system via an MCP client or web browser.")
+Person(user, "Developer / Architect", "Uses the system via CLI or MCP client.")
 
-System_Boundary(mcp_system, "MCP Documentation Server") {
-    Container(spa, "Web Interface", "JavaScript, HTML, CSS", "Provides a visual representation of the document structure and modification diffs.")
-    Container(api, "MCP API Server", "Python, FastAPI", "Provides MCP-compliant API for structured document access and manipulation.")
+System_Boundary(mcp_system, "dacli") {
+    Container(cli, "CLI Tool", "Python, Click", "Provides command-line access to all documentation tools (dacli).")
+    Container(mcp, "MCP Server", "Python, FastMCP", "Provides MCP-compliant tools for LLM integration (dacli-mcp).")
 }
 
 System_Ext(file_system, "File System", "Stores the AsciiDoc and Markdown files.")
 
-Rel(user, spa, "Uses", "HTTPS")
-Rel(user, api, "Makes API calls via MCP Client", "HTTPS")
-Rel(spa, api, "Makes API calls", "HTTPS/JSON")
-Rel(api, file_system, "Reads/Writes", "File System API")
+Rel(user, cli, "Executes commands", "Shell")
+Rel(user, mcp, "Sends tool calls via MCP Client", "stdio")
+Rel(cli, file_system, "Reads/Writes", "File System API")
+Rel(mcp, file_system, "Reads/Writes", "File System API")
 @enduml
 ----
 
-=== Level 3: Components of the MCP API Server
+=== Level 3: Components of the MCP Server
 
-We now zoom into the `MCP API Server` container. It is composed of several components, each with a distinct responsibility, reflecting a classic layered architecture.
+We now zoom into the `MCP Server` container. It is composed of several components, each with a distinct responsibility.
 
 [plantuml, component-detail-api, svg]
 ----
@@ -52,71 +52,51 @@ We now zoom into the `MCP API Server` container. It is composed of several compo
 !include <C4/C4_Component>
 LAYOUT_WITH_LEGEND()
 
-title Component diagram for MCP API Server
+title Component diagram for MCP Server
 
-Container_Boundary(api, "MCP API Server") {
-    Component(api_endpoints, "API Endpoints", "FastAPI", "Receives MCP requests, validates input, and returns responses.")
-    Component(doc_service, "Document Service", "Python", "Orchestrates the business logic for navigation and manipulation use cases.")
-    Component(search_service, "Search Service", "Python", "Provides full-text search across indexed content.")
-    Component(validation_service, "Validation Service", "Python", "Validates document structure, detects issues like circular includes.")
-    Component(parser, "Document Parser", "Python", "Parses AsciiDoc/Markdown files, resolves includes, and builds an Abstract Syntax Tree (AST).")
-    Component(index, "Structure Index", "Python (In-Memory Dictionary)", "Stores the hierarchical structure of the documentation project for fast lookups.")
+Container_Boundary(api, "MCP Server") {
+    Component(mcp_tools, "MCP Tools", "FastMCP", "Exposes tools for navigation, search, manipulation via MCP protocol.")
+    Component(parser, "Document Parsers", "Python", "Parses AsciiDoc/Markdown files, resolves includes, builds AST with line numbers.")
+    Component(index, "Structure Index", "Python (In-Memory)", "Stores hierarchical structure for fast lookups.")
     Component(fs_handler, "File System Handler", "Python", "Performs atomic read/write operations on the file system.")
 }
 
 System_Ext(file_system, "File System")
 
-Rel(api_endpoints, doc_service, "Uses", "Navigation & Manipulation")
-Rel(api_endpoints, search_service, "Uses", "Content Search")
-Rel(api_endpoints, validation_service, "Uses", "Structure Validation")
-Rel(doc_service, parser, "Uses", "To get document AST on initialization")
-Rel(doc_service, index, "Uses", "To find section locations")
-Rel(doc_service, fs_handler, "Uses", "To read/write file content")
-Rel(search_service, index, "Queries")
-Rel(validation_service, index, "Analyzes")
-
+Rel(mcp_tools, index, "Queries", "Structure & Search")
+Rel(mcp_tools, fs_handler, "Uses", "Read/Write content")
 Rel(parser, fs_handler, "Reads files via")
 Rel(index, parser, "Is built by")
 Rel(fs_handler, file_system, "Interacts with")
 @enduml
 ----
 
+NOTE: The CLI tool (`dacli`) shares the same core components (parsers, index, file handler) but operates synchronously via the command line.
+
 === Component Responsibilities
 
-The following table maps components to the API groups defined in the specification:
+The following table maps components to the MCP tools:
 
-.Component to API Group Mapping
-[cols="2,2,3"]
+.Component to MCP Tool Mapping
+[cols="2,3,2"]
 |===
-| Component | API Group | Use Cases
+| Component | Responsibility | MCP Tools
 
-| **API Endpoints**
-| All Groups
-| Request routing, validation, response formatting
+| **MCP Tools**
+| Exposes all functionality via MCP protocol
+| get_structure, get_section, get_sections_at_level, search, get_elements, get_metadata, validate_structure, update_section, insert_content
 
-| **Document Service**
-| Navigation API, Manipulation API
-| UC-01, UC-02, UC-03, UC-09, UC-10
-
-| **Search Service**
-| Content Access API
-| UC-04 (search_content), UC-05 (get_elements)
-
-| **Validation Service**
-| Meta-Information API
-| UC-06 (get_metadata), UC-07 (validate_structure)
-
-| **Document Parser**
-| (Internal)
-| UC-08 (Server Initialization)
+| **Document Parsers**
+| Parse AsciiDoc/Markdown, resolve includes, track line numbers
+| (Internal - used during initialization)
 
 | **Structure Index**
-| (Internal)
-| Supports all read operations
+| In-memory index for fast lookups of sections and elements
+| (Internal - supports all read operations)
 
 | **File System Handler**
-| (Internal)
-| Supports all write operations, atomic writes (ADR-004)
+| Atomic file read/write operations with backup strategy
+| (Internal - supports write operations, ADR-004)
 |===
 
 === Data Models

--- a/src/docs/arc42/chapters/07_deployment_view.adoc
+++ b/src/docs/arc42/chapters/07_deployment_view.adoc
@@ -11,7 +11,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-deployment-view]]
 == Deployment View
 
-This chapter describes the infrastructure and environment for the MCP Documentation Server.
+This chapter describes the infrastructure and environment for dacli.
 
 === Deployment Strategy
 
@@ -23,18 +23,21 @@ For local development and MCP client integration, the server runs directly via u
 
 [source,bash]
 ----
-# Install dependencies and run
+# Install dependencies and run MCP server
 uv sync
-uv run dacli-mcp --project-path /path/to/docs
+uv run dacli-mcp --docs-root /path/to/docs
 
-# Or configure in MCP client (e.g., Claude Desktop)
+# Or use CLI directly
+uv run dacli --docs-root /path/to/docs structure
+
+# Configure in MCP client (e.g., Claude Desktop)
 # ~/.config/claude/claude_desktop_config.json
 {
   "mcpServers": {
-    "docs-server": {
+    "dacli": {
       "command": "uv",
       "args": ["run", "dacli-mcp"],
-      "cwd": "/path/to/mcp-docs-server",
+      "cwd": "/path/to/dacli",
       "env": {
         "PROJECT_PATH": "/path/to/documentation"
       }
@@ -45,7 +48,7 @@ uv run dacli-mcp --project-path /path/to/docs
 
 ==== Docker Deployment
 
-For production or isolated environments, the application is packaged into a Docker container:
+For containerized environments, the application can be packaged into a Docker container:
 
 [source,dockerfile]
 ----
@@ -59,16 +62,16 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 COPY src/ ./src/
-EXPOSE 8000
 
+# MCP server uses stdio transport, no port needed
 CMD ["uv", "run", "dacli-mcp"]
 ----
 
-The Web Interface (SPA) is a set of static files (HTML, CSS, JS) that can be served by any web server or even directly by the FastAPI backend for simplicity.
+NOTE: The MCP server communicates via stdio (standard input/output), not HTTP. The container is typically invoked by an MCP client that manages the stdio streams.
 
 === Production Environment
 
-The production environment is envisioned as a single virtual or physical machine running Docker.
+For production use, dacli runs as a subprocess managed by the MCP client. The typical deployment involves:
 
 [plantuml, deployment-overview, svg]
 ----
@@ -78,15 +81,15 @@ LAYOUT_WITH_LEGEND()
 
 title Deployment Diagram
 
-Deployment_Node('prod_server', 'Production Server', 'e.g. AWS EC2') {
-    Deployment_Node('docker', 'Docker Engine') {
-        Container(api_container, "MCP API Server", "Python/FastAPI")
-        Container(web_server, "Web Server", "Nginx")
+Deployment_Node('user_machine', 'User Machine') {
+    Container(mcp_client, "MCP Client", "e.g. Claude Desktop, IDE Plugin")
+    Deployment_Node('docker', 'Docker Engine (optional)') {
+        Container(dacli_container, "dacli MCP Server", "Python/FastMCP")
     }
     Node('doc_folder', 'Documentation Project', 'File System')
 }
 
-Rel(web_server, api_container, "Forwards API calls to", "HTTPS")
-Rel(api_container, doc_folder, "Mounts and interacts with", "File System API")
+Rel(mcp_client, dacli_container, "Spawns and communicates via", "stdio")
+Rel(dacli_container, doc_folder, "Reads/Writes", "File System API")
 @enduml
 ----

--- a/src/docs/spec/02_api_specification.adoc
+++ b/src/docs/spec/02_api_specification.adoc
@@ -6,28 +6,32 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 :toc:
 
-= MCP Documentation Server - API Specification
+= dacli - API Specification
 :sectnums:
 :icons: font
 
 == Overview
 
-This specification defines the API endpoints of the MCP Documentation Server in OpenAPI style.
+This specification defines the MCP tools provided by dacli. The tools are available via two interfaces:
 
-=== Base URL
+* **MCP Server** (`dacli-mcp`): For LLM integration via MCP protocol over stdio
+* **CLI** (`dacli`): For direct command-line usage (see `06_cli_specification.adoc`)
+
+=== MCP Communication
 
 [source]
 ----
-Base URL: http://localhost:8000/api/v1
-Protocol: MCP over HTTP/JSON
+Transport: stdio (standard input/output)
+Protocol: MCP (Model Context Protocol)
 ----
+
+The MCP server is spawned as a subprocess by an MCP client (e.g., Claude Desktop) and communicates via JSON-RPC over stdio.
 
 === Authentication
 
 [NOTE]
 ====
-The current version does not require authentication (single-tenant).
-API key authentication is planned for future versions.
+The current version does not require authentication (single-tenant, local access only).
 ====
 
 == Data Models
@@ -141,11 +145,11 @@ Standardized error response.
 }
 ----
 
-== API Endpoints
+== MCP Tools
 
-=== Navigation API
+=== Navigation Tools
 
-==== GET /structure
+==== get_structure
 
 Retrieves the hierarchical document structure.
 
@@ -155,7 +159,7 @@ Retrieves the hierarchical document structure.
 |===
 | Parameter | Description
 
-| `max_depth` (query, optional)
+| `max_depth` (int, optional)
 | Maximum depth of returned structure. Default: unlimited.
 |===
 
@@ -187,20 +191,9 @@ Retrieves the hierarchical document structure.
 }
 ----
 
-**Response 500:**
-[source,json]
-----
-{
-  "error": {
-    "code": "INDEX_NOT_READY",
-    "message": "Server index is not initialized"
-  }
-}
-----
-
 '''
 
-==== GET /section/{path}
+==== get_section
 
 Reads the content of a specific section.
 
@@ -210,8 +203,8 @@ Reads the content of a specific section.
 |===
 | Parameter | Description
 
-| `path` (path, required)
-| Hierarchical path to section (URL-encoded)
+| `path` (string, required)
+| Hierarchical path to section (e.g., "introduction.goals")
 |===
 
 **Response 200:**
@@ -247,7 +240,7 @@ Reads the content of a specific section.
 
 '''
 
-==== GET /sections
+==== get_sections_at_level
 
 Retrieves all sections at a specific level.
 
@@ -257,7 +250,7 @@ Retrieves all sections at a specific level.
 |===
 | Parameter | Description
 
-| `level` (query, required)
+| `level` (int, required)
 | Desired nesting depth (1 = chapter)
 |===
 
@@ -280,9 +273,9 @@ Retrieves all sections at a specific level.
 }
 ----
 
-=== Content Access API
+=== Content Access Tools
 
-==== GET /elements
+==== get_elements
 
 Retrieves elements of a specific type.
 
@@ -292,10 +285,10 @@ Retrieves elements of a specific type.
 |===
 | Parameter | Description
 
-| `type` (query, required)
-| Element type: `diagram`, `table`, `code`, `list`, `image`
+| `element_type` (string, optional)
+| Element type: `code`, `table`, `image`, `diagram`, `list`, `admonition`, `plantuml`. None returns all elements.
 
-| `path` (query, optional)
+| `section_path` (string, optional)
 | Restriction to specific section
 |===
 
@@ -337,22 +330,25 @@ Retrieves elements of a specific type.
 
 '''
 
-==== POST /search
+==== search
 
 Searches documentation content.
 
 **Use Case:** UC-04
 
-**Request Body:**
-[source,json]
-----
-{
-  "query": "string",          // Search term (required)
-  "scope": "string",          // Restriction to path (optional)
-  "case_sensitive": false,    // Case sensitivity (optional)
-  "max_results": 50           // Maximum results (optional)
-}
-----
+[cols="1,3"]
+|===
+| Parameter | Description
+
+| `query` (string, required)
+| Search term (case-insensitive)
+
+| `scope` (string, optional)
+| Restriction to path prefix (e.g., "/architecture")
+
+| `max_results` (int, optional)
+| Maximum results to return (default: 50)
+|===
 
 **Response 200:**
 [source,json]
@@ -378,9 +374,9 @@ Searches documentation content.
 }
 ----
 
-=== Content Manipulation API
+=== Content Manipulation Tools
 
-==== PUT /section/{path}
+==== update_section
 
 Updates the content of a section.
 
@@ -390,18 +386,18 @@ Updates the content of a section.
 |===
 | Parameter | Description
 
-| `path` (path, required)
-| Hierarchical path to section
-|===
+| `path` (string, required)
+| Hierarchical path to section (e.g., "introduction.goals")
 
-**Request Body:**
-[source,json]
-----
-{
-  "content": "string",        // New section content (required)
-  "preserve_title": true      // Keep title (optional, default: true)
-}
-----
+| `content` (string, required)
+| New section content
+
+| `preserve_title` (bool, optional)
+| Keep original title (default: true)
+
+| `expected_hash` (string, optional)
+| Hash for optimistic locking - update fails if current content hash doesn't match
+|===
 
 **Response 200:**
 [source,json]
@@ -447,7 +443,7 @@ Updates the content of a section.
 
 '''
 
-==== POST /section/{path}/insert
+==== insert_content
 
 Inserts content relative to a section.
 
@@ -457,18 +453,15 @@ Inserts content relative to a section.
 |===
 | Parameter | Description
 
-| `path` (path, required)
+| `path` (string, required)
 | Hierarchical path to reference section
-|===
 
-**Request Body:**
-[source,json]
-----
-{
-  "position": "string",       // "before" | "after" | "append" (required)
-  "content": "string"         // Content to insert (required)
-}
-----
+| `position` (string, required)
+| Where to insert: "before", "after", or "append"
+
+| `content` (string, required)
+| Content to insert
+|===
 
 **Response 200:**
 [source,json]
@@ -484,9 +477,14 @@ Inserts content relative to a section.
 
 '''
 
-==== PUT /element/{path}/{index}
+==== update_element (planned)
 
-Replaces a specific element.
+[NOTE]
+====
+This tool is planned but not yet implemented.
+====
+
+Replaces a specific element (code block, table, etc.).
 
 **Use Case:** UC-10
 
@@ -494,50 +492,21 @@ Replaces a specific element.
 |===
 | Parameter | Description
 
-| `path` (path, required)
+| `path` (string, required)
 | Hierarchical path to section
 
-| `index` (path, required)
+| `index` (int, required)
 | Index of element within section (0-based)
+
+| `content` (string, required)
+| New element content
 |===
 
-**Request Body:**
-[source,json]
-----
-{
-  "content": "string"         // New element content (required)
-}
-----
+=== Meta-Information Tools
 
-**Response 200:**
-[source,json]
-----
-{
-  "success": true,
-  "element": {
-    "type": "table",
-    "path": "quality.performance",
-    "index": 0
-  }
-}
-----
+==== get_metadata
 
-**Response 404:**
-[source,json]
-----
-{
-  "error": {
-    "code": "ELEMENT_NOT_FOUND",
-    "message": "No element at index 2 in section 'quality.performance'"
-  }
-}
-----
-
-=== Meta-Information API
-
-==== GET /metadata
-
-Retrieves metadata.
+Retrieves metadata about the project or a specific section.
 
 **Use Case:** UC-06
 
@@ -545,8 +514,8 @@ Retrieves metadata.
 |===
 | Parameter | Description
 
-| `path` (query, optional)
-| Path to section. Without: project metadata
+| `path` (string, optional)
+| Path to section. If None, returns project-level metadata.
 |===
 
 **Response 200 (Project):**
@@ -579,36 +548,20 @@ Retrieves metadata.
 
 '''
 
-==== GET /dependencies
+==== get_dependencies (planned)
 
-Retrieves include dependencies.
+[NOTE]
+====
+This tool is planned but not yet implemented.
+====
+
+Retrieves include dependencies and cross-references.
 
 **Use Case:** UC-06 (Extension)
 
-**Response 200:**
-[source,json]
-----
-{
-  "include_tree": {
-    "arc42.adoc": [
-      "chapters/01_introduction.adoc",
-      "chapters/02_constraints.adoc",
-      "chapters/03_context.adoc"
-    ]
-  },
-  "cross_references": [
-    {
-      "from": "decisions.adr-001",
-      "to": "constraints.technical",
-      "type": "reference"
-    }
-  ]
-}
-----
-
 '''
 
-==== POST /validate
+==== validate_structure
 
 Validates the document structure.
 
@@ -652,37 +605,20 @@ Validates the document structure.
 }
 ----
 
-=== System API
+=== System Tools (planned)
 
-==== GET /health
+[NOTE]
+====
+The following tools are planned but not yet implemented. The MCP server currently rebuilds the index automatically after write operations.
+====
 
-Health check endpoint.
+==== get_health (planned)
 
-**Response 200:**
-[source,json]
-----
-{
-  "status": "healthy",
-  "index_ready": true,
-  "indexed_files": 15,
-  "uptime_seconds": 3600
-}
-----
+Returns server health status and index information.
 
-'''
+==== reindex (planned)
 
-==== POST /reindex
-
-Triggers reindexing.
-
-**Response 202:**
-[source,json]
-----
-{
-  "status": "reindexing",
-  "message": "Reindexing started in background"
-}
-----
+Triggers manual reindexing of the documentation.
 
 == CLI Interface
 
@@ -693,39 +629,44 @@ especially for LLMs without MCP support.
 
 == Error Code Reference
 
-[cols="1,1,3"]
+Error responses are returned as dictionaries with an `error` key:
+
+[cols="1,3"]
 |===
-| Code | HTTP Status | Description
+| Code | Description
 
-| `PATH_NOT_FOUND` | 404 | Requested path does not exist
-| `ELEMENT_NOT_FOUND` | 404 | Element at specified index does not exist
-| `INVALID_TYPE` | 400 | Unknown element type
-| `INVALID_POSITION` | 400 | Invalid insert position
-| `INVALID_QUERY` | 400 | Invalid search query
-| `WRITE_FAILED` | 500 | Write operation failed
-| `INDEX_NOT_READY` | 503 | Index not yet initialized
-| `PARSE_ERROR` | 500 | Error parsing a file
+| `PATH_NOT_FOUND` | Requested section path does not exist
+| `ELEMENT_NOT_FOUND` | Element at specified index does not exist
+| `INVALID_TYPE` | Unknown element type
+| `INVALID_POSITION` | Invalid insert position (must be "before", "after", or "append")
+| `WRITE_FAILED` | Write operation failed (file permission, disk full, etc.)
 |===
 
-== Rate Limiting
+== Tool Summary
 
-[NOTE]
-====
-The current version has no rate limiting.
-For production environments, the following is recommended:
+.Implemented MCP Tools
+[cols="2,3"]
+|===
+| Tool | Description
 
-* 100 requests/minute for read operations
-* 20 requests/minute for write operations
-====
+| `get_structure` | Get hierarchical document structure
+| `get_section` | Read content of a specific section
+| `get_sections_at_level` | Get all sections at a nesting level
+| `search` | Search documentation content
+| `get_elements` | Get code blocks, tables, images, etc.
+| `get_metadata` | Get project or section metadata
+| `validate_structure` | Validate document structure
+| `update_section` | Update section content
+| `insert_content` | Insert content before/after sections
+|===
 
-== Versioning
+.Planned Tools
+[cols="2,3"]
+|===
+| Tool | Description
 
-The API uses URL-based versioning (`/api/v1/`).
-
-Changes within a version are backward compatible:
-
-* New optional parameters
-* New response fields
-* New endpoints
-
-Breaking changes require a new version (`/api/v2/`).
+| `update_element` | Replace a specific element (code, table)
+| `get_dependencies` | Get include dependencies
+| `get_health` | Server health status
+| `reindex` | Trigger manual reindexing
+|===


### PR DESCRIPTION
## Summary

This PR corrects significant inconsistencies between the arc42 architecture documentation and the actual codebase.

### Key Changes

**Removed non-existent Web Interface:**
- The documentation referenced a Web SPA (JavaScript, HTML, CSS) that was never implemented
- Removed from Building Block View Level 2, Deployment View, and Solution Strategy

**Fixed protocol documentation:**
- MCP uses **stdio** transport, not HTTPS as documented
- Updated Technical Context diagrams

**Updated technology stack:**
- FastMCP (not "mcp[cli]") is the actual MCP framework
- Click is the CLI framework (not documented before)
- Removed difflib reference (was for non-existent Web UI diffs)

**Renamed throughout:**
- Changed "MCP Documentation Server" to "dacli" consistently

**Converted API Specification:**
- Changed from REST endpoint notation (`GET /structure`) to MCP tool notation (`get_structure`)
- Marked unimplemented tools (`update_element`, `get_dependencies`, `get_health`, `reindex`) as "planned"
- Removed HTTP-specific sections

**Fixed CLI parameter:**
- `--project-path` → `--docs-root`

### Files Changed (11)

| File | Change |
|------|--------|
| `05_building_block_view.adoc` | Removed Web Interface, added CLI, updated diagrams |
| `07_deployment_view.adoc` | Removed Nginx, fixed parameter, updated diagrams |
| `04_solution_strategy.adoc` | FastMCP instead of mcp[cli], removed difflib |
| `03_context_and_scope.adoc` | stdio instead of HTTPS, updated diagrams |
| `02_api_specification.adoc` | Complete rewrite from REST to MCP tools |
| `01_introduction_and_goals.adoc` | Renamed to dacli |
| `02_architecture_constraints.adoc` | Removed "Web Interface" phase |
| `arc42.adoc` | Renamed title |
| User Manual files | Consistent naming |

## Test plan

- [ ] Review documentation for accuracy
- [ ] Verify PlantUML diagrams render correctly
- [ ] Check all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)