### PR TITLE
fix(cli): Fix insert blank line and preserve_title bugs (#119, #120)

### DIFF
--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -817,7 +817,8 @@ def insert(ctx: CliContext, path: str, position: str, content: str):
                 if prev_line.strip():
                     insert_content = "\n" + insert_content
             # Add blank line after content if next line is a heading
-            next_line_idx = end_line  # 0-based index (end_line is 1-based, so lines[end_line] is next)
+            # 0-based index (end_line is 1-based, so lines[end_line] is the next line)
+            next_line_idx = end_line
             if next_line_is_heading(lines, next_line_idx) and not starts_with_heading:
                 insert_content = ensure_trailing_blank_line(insert_content)
             new_lines = lines[:end_line] + [insert_content] + lines[end_line:]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1130,10 +1130,10 @@ class TestCliUpdateCommand:
         assert "Original content" not in content
 
     def test_update_stdin_with_heading_preserves_title(self, tmp_path):
-        """Update with stdin content starting with heading should preserve original title (Issue #120).
+        """Update with stdin heading should preserve original title (Issue #120).
 
-        When preserve_title=true (default), the original title should always be kept,
-        even if the stdin content starts with a heading.
+        When preserve_title=true (default), the original title should always
+        be kept, even if the stdin content starts with a heading.
         """
         from dacli.cli import cli
 
@@ -1163,7 +1163,7 @@ class TestCliUpdateCommand:
         assert "New content from stdin" in content
 
     def test_update_stdin_with_heading_preserves_title_asciidoc(self, tmp_path):
-        """Update with stdin content starting with heading should preserve title in AsciiDoc (Issue #120)."""
+        """Update with stdin heading should preserve title in AsciiDoc (#120)."""
         from dacli.cli import cli
 
         doc_file = tmp_path / "test.adoc"
@@ -1249,7 +1249,7 @@ Content B.
                 if next_content_idx < len(lines) and lines[next_content_idx].startswith("=="):
                     # There should be at least one blank line between
                     blank_lines = next_content_idx - i - 1
-                    assert blank_lines >= 1, f"Should have blank line before heading, found {blank_lines}"
+                    assert blank_lines >= 1, f"Need blank line before heading, got {blank_lines}"
                 break
 
     def test_insert_adds_blank_line_after_content_before_heading_markdown(self, tmp_path):
@@ -1293,5 +1293,5 @@ Content B.
                     next_content_idx += 1
                 if next_content_idx < len(lines) and lines[next_content_idx].startswith("#"):
                     blank_lines = next_content_idx - i - 1
-                    assert blank_lines >= 1, f"Should have blank line before heading, found {blank_lines}"
+                    assert blank_lines >= 1, f"Need blank line before heading, got {blank_lines}"
                 break


### PR DESCRIPTION
## Summary
- **Bug #119**: Insert command now adds blank line after inserted content when the next line is a heading
- **Bug #120**: Update command with `preserve_title=true` now correctly strips heading from stdin content

## Changes
- Modified `update` command to strip heading from content when `preserve_title=true` and always prepend original title
- Modified `insert` command to add trailing blank line when next line in document is a heading
- Added 4 new tests to verify both bug fixes

## Test plan
- [x] New tests for Bug #119 (blank line after insert) pass
- [x] New tests for Bug #120 (preserve_title with stdin heading) pass
- [x] All 368 existing tests pass
- [ ] CI pipeline passes

Closes #119
Closes #120

🤖 Generated with [Claude Code](https://claude.ai/claude-code)