### PR TITLE
feat: Add Mermaid/Ditaa support and fix whitespace in diagram blocks (Issue #122)

### DIFF
--- a/src/docs/spec/05_asciidoc_parser.adoc
+++ b/src/docs/spec/05_asciidoc_parser.adoc
@@ -477,7 +477,7 @@ class AsciidocSection:
 @dataclass
 class AsciidocElement:
     """An extractable element."""
-    type: Literal["code", "plantuml", "table", "image", "admonition"]
+    type: Literal["code", "plantuml", "mermaid", "ditaa", "table", "image", "admonition", "list"]
     source_location: SourceLocation
     attributes: dict[str, Any]          # Type-specific attributes
     parent_section: str                 # Path of containing section
@@ -771,6 +771,12 @@ SOURCE_BLOCK_PATTERN = r'^\[source(?:,\s*(\w+))?\]$'
 
 # PlantUML block start
 PLANTUML_PATTERN = r'^\[plantuml(?:,\s*([^,\]]+))?(?:,\s*(\w+))?\]$'
+
+# Mermaid block start (Issue #122)
+MERMAID_PATTERN = r'^\[mermaid(?:,\s*([^,\]]+))?(?:,\s*(\w+))?\]$'
+
+# Ditaa block start (Issue #122)
+DITAA_PATTERN = r'^\[ditaa(?:,\s*([^,\]]+))?(?:,\s*(\w+))?\]$'
 
 # Block delimiter
 BLOCK_DELIMITER = r'^(-{4,}|={4,}|\*{4,}|_{4,})$'


### PR DESCRIPTION
## Summary
- Fix PlantUML and code block regex patterns to allow whitespace after commas
- Add support for Mermaid diagram blocks `[mermaid, name, format]`
- Add support for Ditaa diagram blocks `[ditaa, name, format]`
- Update Element type in spec to include `mermaid`, `ditaa`, and `list` types

## Root Cause
The regex patterns used `,([a-z...])` instead of `,\s*([a-z...])` which prevented matching blocks like `[plantuml, name, svg]` (with spaces after commas).

## Changes
- **src/dacli/asciidoc_parser.py**: Updated regex patterns and added Mermaid/Ditaa block detection
- **src/docs/spec/05_asciidoc_parser.adoc**: Updated Element type and added new patterns
- **tests/test_asciidoc_parser.py**: Added 6 new tests for diagram element detection

## Test plan
- [x] New tests for PlantUML with whitespace pass
- [x] New tests for source blocks with whitespace pass  
- [x] New tests for Mermaid blocks pass
- [x] New tests for Ditaa blocks pass
- [x] All 370 existing tests still pass
- [x] Linting passes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)