### PR TITLE
fix: Preserve umlauts in Markdown paths (Issue #138)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.2.1"
+version = "0.2.2"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/dacli/markdown_parser.py
+++ b/src/dacli/markdown_parser.py
@@ -48,10 +48,11 @@ def slugify(text: str) -> str:
         text: Text to slugify
 
     Returns:
-        Lowercase, hyphenated slug
+        Lowercase, hyphenated slug with Unicode characters preserved
     """
-    # Remove special characters (ASCII-only word chars), replace spaces with hyphens
-    slug = re.sub(r"[^\w\s-]", "", text.lower(), flags=re.ASCII)
+    # Remove special characters but preserve Unicode word characters (umlauts, etc.)
+    # Note: No re.ASCII flag to allow Unicode \w matching (consistent with AsciiDoc parser)
+    slug = re.sub(r"[^\w\s-]", "", text.lower())
     slug = re.sub(r"[\s_]+", "-", slug)
     slug = re.sub(r"-+", "-", slug)
     return slug.strip("-")

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -216,6 +216,37 @@ class TestHeadingPaths:
         # Document title has file prefix as path (Issue #130, ADR-008)
         assert doc.sections[0].path == file_prefix
 
+    def test_path_preserves_umlauts(self):
+        """Paths preserve German umlauts (Issue #138).
+
+        Umlauts should be preserved in paths to be consistent with AsciiDoc
+        behavior and to make paths typeable/predictable.
+        """
+        from dacli.markdown_parser import MarkdownStructureParser
+
+        parser = MarkdownStructureParser()
+        content = """# Dokumentation
+
+## Einführung
+
+Content about introduction.
+
+## Übersicht
+
+Content about overview.
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(content)
+            f.flush()
+            file_path = Path(f.name)
+            file_prefix = file_path.stem
+            doc = parser.parse_file(file_path)
+
+        root = doc.sections[0]
+        # Umlauts should be preserved in paths, just lowercased
+        assert root.children[0].path == f"{file_prefix}:einführung"
+        assert root.children[1].path == f"{file_prefix}:übersicht"
+
     def test_duplicate_heading_titles_get_disambiguated_paths(self):
         """Test that headings with same title at same level get disambiguated paths.
 

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Remove `re.ASCII` flag from `slugify` function to preserve Unicode word characters
- This makes Markdown parser behavior consistent with AsciiDoc parser

**Before:** `"Einführung"` → `"einfhrung"` (ü stripped)
**After:** `"Einführung"` → `"einführung"` (ü preserved)

## Root Cause

The Markdown `slugify` function used `flags=re.ASCII` which restricts `\w` to ASCII characters only, stripping all Unicode characters including German umlauts.

## Test plan

- [x] Added test `test_path_preserves_umlauts` in test_markdown_parser.py
- [x] All 407 tests pass
- [x] Ruff linting passes

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)