### PR TITLE
refactor!: Remove preview field from element responses (Issue #142)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.2.3"
+version = "0.3.0"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/src/dacli/api/content.py
+++ b/src/dacli/api/content.py
@@ -186,16 +186,7 @@ def get_elements(
         element_index = section_element_counts[section_path]
         section_element_counts[section_path] += 1
 
-        # Build preview from attributes if available
-        preview = None
-        if elem.attributes:
-            # Build preview string from first few attributes
-            attr_parts = []
-            for key, value in list(elem.attributes.items())[:3]:
-                attr_parts.append(f"{key}={value}")
-            if attr_parts:
-                preview = ", ".join(attr_parts)
-
+        # Note: preview field removed in Issue #142 as redundant
         element_items.append(
             ElementItem(
                 type=type,  # Use API type, not internal type
@@ -210,7 +201,6 @@ def get_elements(
                     # TODO: Update this when SourceLocation includes an end_line range.
                     end_line=elem.source_location.line,
                 ),
-                preview=preview,
             )
         )
 

--- a/src/dacli/api/models.py
+++ b/src/dacli/api/models.py
@@ -123,7 +123,7 @@ class ElementItem(BaseModel):
     path: str = Field(description="Section path containing this element")
     index: int = Field(description="Index of element within its section")
     location: ElementLocation
-    preview: str | None = Field(default=None, description="Preview text of the element")
+    # Note: preview field removed in Issue #142 as redundant
 
 
 class ElementsResponse(BaseModel):

--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -479,60 +479,8 @@ def elements(ctx: CliContext, element_type: str | None, section_path: str | None
         section_path=section_path,
     )
 
-    def build_preview(elem) -> str | None:
-        """Build preview string from element attributes.
-
-        Generates format-specific previews based on source file type:
-        - Markdown (.md): Uses Markdown syntax
-        - AsciiDoc (.adoc): Uses AsciiDoc syntax
-        """
-        attrs = elem.attributes
-        file_path = str(elem.source_location.file)
-        is_markdown = file_path.endswith(".md")
-
-        if elem.type == "plantuml":
-            # PlantUML is AsciiDoc-specific
-            parts = ["plantuml"]
-            if attrs.get("name"):
-                parts.append(attrs["name"])
-            if attrs.get("format"):
-                parts.append(attrs["format"])
-            return f"[{', '.join(parts)}]"
-        elif elem.type == "code":
-            lang = attrs.get("language", "")
-            if is_markdown:
-                return f"```{lang}" if lang else "```"
-            return f"[source, {lang}]" if lang else "[source]"
-        elif elem.type == "image":
-            # Markdown uses "src", AsciiDoc uses "target"
-            target = attrs.get("src", "") or attrs.get("target", "")
-            alt = attrs.get("alt", "")
-            if is_markdown:
-                return f"![{alt}]({target})"
-            return f"image::{target}[{alt}]"
-        elif elem.type == "table":
-            if is_markdown:
-                # For Markdown, show first header row indicator
-                return "| ... |"
-            return "|==="
-        elif elem.type == "admonition":
-            atype = attrs.get("admonition_type", "NOTE")
-            full_content = attrs.get("content", "")
-            if is_markdown:
-                # Markdown blockquote style
-                if len(full_content) > 30:
-                    return f"> **{atype}:** {full_content[:30]}..."
-                return f"> **{atype}:** {full_content}"
-            if len(full_content) > 30:
-                return f"{atype}: {full_content[:30]}..."
-            return f"{atype}: {full_content}"
-        elif elem.type == "list":
-            list_type = attrs.get("list_type", "unordered")
-            if is_markdown:
-                return "- ..." if list_type == "unordered" else "1. ..."
-            return f"{list_type} list"
-        return None
-
+    # Note: preview field removed in Issue #142 as redundant
+    # The type field is sufficient to identify element kind
     result = {
         "elements": [
             {
@@ -543,7 +491,6 @@ def elements(ctx: CliContext, element_type: str | None, section_path: str | None
                     "start_line": e.source_location.line,
                     "end_line": e.source_location.end_line,
                 },
-                "preview": build_preview(e),
             }
             for e in elems
         ],

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -269,68 +269,16 @@ def create_mcp_server(
             section_path: Filter by section path (e.g., '/architecture').
 
         Returns:
-            Dictionary with 'elements' (list of elements with type, location,
-            preview) and 'count'.
+            Dictionary with 'elements' (list of elements with type, location)
+            and 'count'.
         """
         elements = index.get_elements(
             element_type=element_type,
             section_path=section_path,
         )
 
-        def build_preview(elem) -> str | None:
-            """Build preview string from element attributes.
-
-            Generates format-specific previews based on source file type:
-            - Markdown (.md): Uses Markdown syntax
-            - AsciiDoc (.adoc): Uses AsciiDoc syntax
-            """
-            attrs = elem.attributes
-            file_path = str(elem.source_location.file)
-            is_markdown = file_path.endswith(".md")
-
-            if elem.type == "plantuml":
-                # PlantUML is AsciiDoc-specific
-                parts = ["plantuml"]
-                if attrs.get("name"):
-                    parts.append(attrs["name"])
-                if attrs.get("format"):
-                    parts.append(attrs["format"])
-                return f"[{', '.join(parts)}]"
-            elif elem.type == "code":
-                lang = attrs.get("language", "")
-                if is_markdown:
-                    return f"```{lang}" if lang else "```"
-                return f"[source, {lang}]" if lang else "[source]"
-            elif elem.type == "image":
-                # Markdown uses "src", AsciiDoc uses "target"
-                target = attrs.get("src", "") or attrs.get("target", "")
-                alt = attrs.get("alt", "")
-                if is_markdown:
-                    return f"![{alt}]({target})"
-                return f"image::{target}[{alt}]"
-            elif elem.type == "table":
-                if is_markdown:
-                    # For Markdown, show first header row indicator
-                    return "| ... |"
-                return "|==="
-            elif elem.type == "admonition":
-                atype = attrs.get("admonition_type", "NOTE")
-                full_content = attrs.get("content", "")
-                if is_markdown:
-                    # Markdown blockquote style
-                    if len(full_content) > 30:
-                        return f"> **{atype}:** {full_content[:30]}..."
-                    return f"> **{atype}:** {full_content}"
-                if len(full_content) > 30:
-                    return f"{atype}: {full_content[:30]}..."
-                return f"{atype}: {full_content}"
-            elif elem.type == "list":
-                list_type = attrs.get("list_type", "unordered")
-                if is_markdown:
-                    return "- ..." if list_type == "unordered" else "1. ..."
-                return f"{list_type} list"
-            return None
-
+        # Note: preview field removed in Issue #142 as redundant
+        # The type field is sufficient to identify element kind
         return {
             "elements": [
                 {
@@ -341,7 +289,6 @@ def create_mcp_server(
                         "start_line": e.source_location.line,
                         "end_line": e.source_location.end_line,
                     },
-                    "preview": build_preview(e),
                 }
                 for e in elements
             ],

--- a/src/docs/50-user-manual/20-mcp-tools.adoc
+++ b/src/docs/50-user-manual/20-mcp-tools.adoc
@@ -142,8 +142,7 @@ Get code blocks, tables, images, and other elements.
         "file": "/docs/example.adoc",
         "line": 25
       },
-      "preview": "[python] def hello()...",
-      "section_path": "examples.python"
+      "parent_section": "examples.python"
     }
   ],
   "count": 5

--- a/src/docs/50-user-manual/50-tutorial.adoc
+++ b/src/docs/50-user-manual/50-tutorial.adoc
@@ -220,14 +220,12 @@ Output:
     {
       "type": "code",
       "parent_section": "examples.python",
-      "location": {"file": "/path/to/docs/examples.adoc", "start_line": 25},
-      "preview": "[source, python]"
+      "location": {"file": "/path/to/docs/examples.adoc", "start_line": 25}
     },
     {
       "type": "code",
       "parent_section": "api-reference.endpoints",
-      "location": {"file": "/path/to/docs/api.adoc", "start_line": 102},
-      "preview": "[source, bash]"
+      "location": {"file": "/path/to/docs/api.adoc", "start_line": 102}
     }
   ],
   "count": 15

--- a/src/docs/spec/02_api_specification.adoc
+++ b/src/docs/spec/02_api_specification.adoc
@@ -74,8 +74,7 @@ Represents a special element (table, code, diagram).
   "type": "string",           // "table" | "code" | "diagram" | "list" | "image"
   "path": "string",           // Path to containing section
   "index": "integer",         // Index within section
-  "location": "SectionLocation",
-  "preview": "string"         // Preview/title (optional)
+  "location": "SectionLocation"
 }
 ----
 
@@ -306,8 +305,7 @@ Retrieves elements of a specific type.
         "file": "chapters/03_context.adoc",
         "start_line": 25,
         "end_line": 45
-      },
-      "preview": "[plantuml, technical-context, svg]"
+      }
     }
   ],
   "count": 8

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -225,113 +225,20 @@ class TestGetElements:
         assert "elements" in result.data
         assert isinstance(result.data["elements"], list)
 
-    async def test_get_elements_preview_format(self, mcp_client: Client):
-        """get_elements returns properly formatted preview strings."""
+    async def test_get_elements_has_no_preview_field(self, mcp_client: Client):
+        """get_elements should not return preview field (Issue #142).
+
+        The preview field was removed as redundant - type field is sufficient.
+        """
         result = await mcp_client.call_tool("get_elements", arguments={})
 
         elements = result.data["elements"]
         for elem in elements:
-            preview = elem.get("preview")
-            if preview:
-                # Check preview follows expected formats
-                elem_type = elem["type"]
-                if elem_type == "code":
-                    assert preview.startswith("[source")
-                elif elem_type == "plantuml":
-                    assert preview.startswith("[plantuml")
-                elif elem_type == "image":
-                    assert preview.startswith("image::")
-                elif elem_type == "table":
-                    assert preview == "|==="
-                elif elem_type == "list":
-                    assert "list" in preview
-
-
-class TestMarkdownElementPreview:
-    """Tests for Markdown element preview format (Issue #137).
-
-    Element previews should use Markdown syntax for Markdown files,
-    not AsciiDoc syntax.
-    """
-
-    @pytest_asyncio.fixture
-    async def md_doc_dir(self, tmp_path: Path):
-        """Create temp directory with Markdown documentation."""
-        md_file = tmp_path / "test.md"
-        md_file.write_text("""# Test Document
-
-## Code Example
-
-```python
-def hello():
-    print("Hello")
-```
-
-## Table Example
-
-| Name | Value |
-|------|-------|
-| A    | 1     |
-
-## Image Example
-
-![Logo](images/logo.png)
-
-## List Example
-
-- Item 1
-- Item 2
-""", encoding="utf-8")
-        return tmp_path
-
-    @pytest_asyncio.fixture
-    async def md_mcp_client(self, md_doc_dir: Path):
-        """Create MCP client with Markdown documentation."""
-        mcp = create_mcp_server(docs_root=md_doc_dir)
-        async with Client(transport=mcp) as client:
-            yield client
-
-    async def test_code_preview_markdown_syntax(self, md_mcp_client: Client):
-        """Code block preview uses ```language for Markdown files."""
-        result = await md_mcp_client.call_tool(
-            "get_elements", arguments={"element_type": "code"}
-        )
-
-        assert result.data["count"] == 1
-        preview = result.data["elements"][0]["preview"]
-        assert preview == "```python", f"Expected '```python', got '{preview}'"
-
-    async def test_table_preview_markdown_syntax(self, md_mcp_client: Client):
-        """Table preview uses | Col | for Markdown files."""
-        result = await md_mcp_client.call_tool(
-            "get_elements", arguments={"element_type": "table"}
-        )
-
-        assert result.data["count"] == 1
-        preview = result.data["elements"][0]["preview"]
-        assert preview.startswith("|"), f"Expected '|' prefix, got '{preview}'"
-        assert "|===" not in preview
-
-    async def test_image_preview_markdown_syntax(self, md_mcp_client: Client):
-        """Image preview uses ![alt](src) for Markdown files."""
-        result = await md_mcp_client.call_tool(
-            "get_elements", arguments={"element_type": "image"}
-        )
-
-        assert result.data["count"] == 1
-        preview = result.data["elements"][0]["preview"]
-        expected = "![Logo](images/logo.png)"
-        assert preview == expected, f"Expected '{expected}', got '{preview}'"
-
-    async def test_list_preview_markdown_syntax(self, md_mcp_client: Client):
-        """List preview uses - ... for Markdown files."""
-        result = await md_mcp_client.call_tool(
-            "get_elements", arguments={"element_type": "list"}
-        )
-
-        assert result.data["count"] == 1
-        preview = result.data["elements"][0]["preview"]
-        assert preview == "- ...", f"Expected '- ...', got '{preview}'"
+            assert "preview" not in elem, f"Element should not have preview: {elem}"
+            # But should have essential fields
+            assert "type" in elem
+            assert "parent_section" in elem
+            assert "location" in elem
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Remove redundant `preview` field from element responses in CLI, MCP, and REST API
- The `type` field already identifies element kind, making `preview` redundant
- Also fixes duplicate `build_preview` function issue (#141)

## Breaking Change

The `preview` field has been removed from:
- CLI `elements` command output
- MCP `get_elements` tool response
- REST API `/elements` endpoint response

Clients relying on the `preview` field will need to be updated.

## Changes

- Remove `build_preview()` function from `cli.py` and `mcp_app.py`
- Remove `preview` field from `ElementItem` model in `api/models.py`
- Update API specification and user documentation
- Replace preview-format tests with no-preview tests
- Bump version to 0.3.0 (breaking change)

## Test plan

- [x] All 408 tests passing
- [x] New tests verify `preview` field is NOT present in responses
- [x] Linting passes

Fixes #142
Fixes #141

🤖 Generated with [Claude Code](https://claude.ai/code)