### PR TITLE
fix: Create root section for empty files (Issue #145)

### DIFF
--- a/src/dacli/asciidoc_parser.py
+++ b/src/dacli/asciidoc_parser.py
@@ -415,8 +415,19 @@ class AsciidocStructureParser:
         Returns:
             Tuple of (list of top-level sections, document title)
         """
-        if not lines:
-            return [], ""
+        # Check if file is empty or contains only whitespace (Issue #145)
+        is_empty = not lines or all(line[0].strip() == "" for line in lines)
+        if is_empty:
+            # Create minimal root section for empty files
+            file_prefix = self._get_file_prefix(file_path)
+            filename = file_path.stem  # Filename without extension
+            root_section = Section(
+                title=filename,
+                level=0,
+                path=file_prefix,
+                source_location=SourceLocation(file=file_path, line=1, end_line=1),
+            )
+            return [root_section], filename
 
         if attributes is None:
             attributes = {}

--- a/src/dacli/markdown_parser.py
+++ b/src/dacli/markdown_parser.py
@@ -300,13 +300,27 @@ class MarkdownStructureParser:
         Returns:
             Tuple of (sections list, document title)
         """
+        # Calculate file prefix early for empty file handling (Issue #145)
+        file_prefix = self._get_file_prefix(file_path)
+
+        # Check if file is empty or contains only whitespace (Issue #145)
+        is_empty = not lines or all(line.strip() == "" for line in lines)
+        if is_empty:
+            # Create minimal root section for empty files
+            filename = file_path.stem  # Filename without extension
+            root_section = Section(
+                title=filename,
+                level=0,
+                path=file_prefix,
+                source_location=SourceLocation(file=file_path, line=1, end_line=1),
+            )
+            return [root_section], filename
+
         sections: list[Section] = []
         section_stack: list[Section] = []
         document_title = ""
         # Track used paths for disambiguation (Issue #123)
         used_paths: dict[str, int] = {}
-        # Calculate file prefix for cross-document unique paths (Issue #130, ADR-008)
-        file_prefix = self._get_file_prefix(file_path)
 
         def get_unique_path(base_path: str) -> str:
             """Get a unique path, appending -2, -3 etc. for duplicates."""


### PR DESCRIPTION
## Summary

- Empty files (0 bytes or whitespace-only) now create a minimal root section with the filename as title
- This makes empty files accessible via the API instead of returning PATH_NOT_FOUND
- Both AsciiDoc and Markdown parsers updated

## Changes

- `AsciidocStructureParser`: Check for empty/whitespace content at start of `_parse_sections()`, create root section
- `MarkdownStructureParser`: Same handling for empty files  
- Added 9 new tests for empty file edge cases
- Updated 1 existing test expectation

## Test plan

- [x] All 422 tests passing
- [x] Linting passes
- [x] New tests cover: empty file, whitespace-only, subdirectory paths

Fixes #145

🤖 Generated with [Claude Code](https://claude.ai/code)