### PR TITLE
feat: Add --recursive flag to elements command (Issue #147)

### DIFF
--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -466,6 +466,7 @@ Examples:
   dacli elements --type table            # Only tables
   dacli elements api                     # Elements in 'api' section
   dacli elements --section api           # Same as above (--section still works)
+  dacli elements api --recursive         # Elements in 'api' and all subsections
   dacli --format json el --type image    # JSON output using alias
 """)
 @click.argument("section_path_arg", required=False, default=None)
@@ -473,15 +474,18 @@ Examples:
               help="Element type: code, table, image, diagram, list")
 @click.option("--section", "section_path_opt", default=None,
               help="Filter by section path (alternative to positional argument)")
+@click.option("--recursive", is_flag=True, default=False,
+              help="Include elements from child sections")
 @pass_context
 def elements(ctx: CliContext, section_path_arg: str | None, element_type: str | None,
-             section_path_opt: str | None):
+             section_path_opt: str | None, recursive: bool):
+    """Get elements (code blocks, tables, images) from documentation."""
     # Use positional argument if provided, otherwise fall back to --section option
     section_path = section_path_arg or section_path_opt
-    """Get elements (code blocks, tables, images) from documentation."""
     elems = ctx.index.get_elements(
         element_type=element_type,
         section_path=section_path,
+        recursive=recursive,
     )
 
     # Note: preview field removed in Issue #142 as redundant

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -257,6 +257,7 @@ def create_mcp_server(
     def get_elements(
         element_type: str | None = None,
         section_path: str | None = None,
+        recursive: bool = False,
     ) -> dict:
         """Get elements (code blocks, tables, images) from the documentation.
 
@@ -267,6 +268,8 @@ def create_mcp_server(
             element_type: Filter by type - 'code', 'table', 'image',
                           'diagram', 'list'. None returns all elements.
             section_path: Filter by section path (e.g., '/architecture').
+            recursive: If True, include elements from child sections.
+                       If False (default), only exact section matches.
 
         Returns:
             Dictionary with 'elements' (list of elements with type, location)
@@ -275,6 +278,7 @@ def create_mcp_server(
         elements = index.get_elements(
             element_type=element_type,
             section_path=section_path,
+            recursive=recursive,
         )
 
         # Note: preview field removed in Issue #142 as redundant

--- a/src/dacli/structure_index.py
+++ b/src/dacli/structure_index.py
@@ -309,12 +309,15 @@ class StructureIndex:
         self,
         element_type: str | None = None,
         section_path: str | None = None,
+        recursive: bool = False,
     ) -> list[Element]:
         """Get elements, optionally filtered by type and/or section.
 
         Args:
             element_type: Optional type filter (code, table, image, etc.)
             section_path: Optional section path filter
+            recursive: If True, include elements from child sections (prefix match).
+                       If False, use exact section match (default).
 
         Returns:
             List of matching elements
@@ -327,7 +330,18 @@ class StructureIndex:
 
         # Further filter by section if specified
         if section_path is not None:
-            elements = [e for e in elements if e.parent_section == section_path]
+            if recursive:
+                # Prefix match: include elements from child sections
+                # Match exact path or path followed by separator (. or :)
+                elements = [
+                    e for e in elements
+                    if e.parent_section == section_path
+                    or e.parent_section.startswith(section_path + ".")
+                    or e.parent_section.startswith(section_path + ":")
+                ]
+            else:
+                # Exact match only
+                elements = [e for e in elements if e.parent_section == section_path]
 
         return elements
 

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -176,13 +176,17 @@ Lists elements (code blocks, tables, etc.).
 
 [source,bash]
 ----
-dacli elements [SECTION_PATH] [--type TYPE] [--section PATH]
+dacli elements [SECTION_PATH] [--type TYPE] [--section PATH] [--recursive]
 ----
 
 The section path can be provided as a positional argument or via the `--section` option.
 Both forms are equivalent: `dacli elements api` and `dacli elements --section api`.
 
-**Type options:** `code`, `table`, `image`, `diagram`, `list`, `admonition`
+**Options:**
+
+* `--type TYPE`: Element type filter - `code`, `table`, `image`, `diagram`, `list`, `admonition`
+* `--section PATH`: Filter by section path (alternative to positional argument)
+* `--recursive`: Include elements from child sections (default: exact match only)
 
 == Meta-Information Commands
 


### PR DESCRIPTION
## Summary

- The `elements` command now supports hierarchical section filtering with the `--recursive` flag
- Without the flag (default): exact section match only
- With the flag: includes elements from child sections

## Changes

- Added `--recursive` flag to CLI `elements` command
- Added `recursive` parameter to `StructureIndex.get_elements()`
- Added `recursive` parameter to MCP `get_elements` tool
- Updated CLI specification documentation
- Added 4 new tests for recursive filtering behavior

## Usage

```bash
# Without --recursive (exact match)
dacli elements --section api           # Only elements directly in 'api' section

# With --recursive (prefix match)
dacli elements --section api --recursive  # Elements in 'api' and all subsections
```

## Implementation Details

The recursive flag uses prefix matching with proper separator handling:
- Matches exact path OR path followed by `.` separator OR path followed by `:` separator
- This ensures `api` matches `api.endpoints` but not `api-v2`

## Test plan

- [x] All 431 tests pass
- [x] Test exact match behavior without recursive flag
- [x] Test recursive includes child sections  
- [x] Test recursive with multiple nesting levels
- [x] Test --recursive flag shown in help

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)