### PR TITLE
fix: Detect all unclosed blocks in validate command (Issue #157)

### DIFF
--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
## Summary

- Fixed bug where validate command only detected the **last** unclosed block instead of **all** unclosed blocks
- Replaced single-element tracking with a stack
- Now multiple unclosed blocks (e.g., code block + table) are all properly detected and reported

## Root Cause

The parser used a single variable to track open blocks. When a new block was opened before the previous one was closed, the previous one was forgotten.

## Solution

- Use a stack (open_blocks) instead of a single variable
- Block start: append to stack
- Block end: pop from stack and set end_line
- End of parsing: iterate over all remaining elements and generate warnings

## Test plan

- [x] Added test for multiple unclosed blocks
- [x] All 435 tests pass
- [x] Linting passes

Fixes #157

Generated with Claude Code