### PR TITLE
refactor: Extract shared API dependencies (Issue #164)

### DIFF
--- a/src/dacli/api/app.py
+++ b/src/dacli/api/app.py
@@ -6,7 +6,7 @@ Creates and configures the FastAPI application with all routers.
 from fastapi import FastAPI
 
 from dacli import __version__
-from dacli.api import content, manipulation, navigation
+from dacli.api import content, dependencies, manipulation, navigation
 from dacli.structure_index import StructureIndex
 
 
@@ -28,11 +28,9 @@ def create_app(index: StructureIndex | None = None) -> FastAPI:
         redoc_url="/redoc",
     )
 
-    # Set the index for routers
+    # Set the index for all routers (shared via dependencies module)
     if index is not None:
-        navigation.set_index(index)
-        content.set_index(index)
-        manipulation.set_index(index)
+        dependencies.set_index(index)
 
     # Include routers
     app.include_router(navigation.router)

--- a/src/dacli/api/content.py
+++ b/src/dacli/api/content.py
@@ -9,6 +9,7 @@ import time
 
 from fastapi import APIRouter, HTTPException, Query
 
+from dacli.api.dependencies import get_index
 from dacli.api.models import (
     VALID_ELEMENT_TYPES,
     ElementItem,
@@ -20,12 +21,8 @@ from dacli.api.models import (
     SearchResponse,
     SearchResultItem,
 )
-from dacli.structure_index import StructureIndex
 
 router = APIRouter(prefix="/api/v1", tags=["Content Access"])
-
-# Global index reference - will be set by create_app
-_index: StructureIndex | None = None
 
 # Mapping from internal element types to API types
 ELEMENT_TYPE_TO_API = {
@@ -42,27 +39,6 @@ API_TYPE_TO_ELEMENT = {
     "table": ["table"],
     "image": ["image"],
 }
-
-
-def set_index(index: StructureIndex) -> None:
-    """Set the global structure index."""
-    global _index
-    _index = index
-
-
-def get_index() -> StructureIndex:
-    """Get the global structure index."""
-    if _index is None:
-        raise HTTPException(
-            status_code=503,
-            detail=ErrorResponse(
-                error=ErrorDetail(
-                    code="INDEX_NOT_READY",
-                    message="Server index is not initialized",
-                )
-            ).model_dump(),
-        )
-    return _index
 
 
 @router.post(

--- a/src/dacli/api/dependencies.py
+++ b/src/dacli/api/dependencies.py
@@ -1,0 +1,45 @@
+"""Shared dependencies for API routers.
+
+This module provides the shared StructureIndex instance used by all API routers.
+The index is set once during app initialization and accessed by routers.
+"""
+
+from fastapi import HTTPException
+
+from dacli.api.models import ErrorDetail, ErrorResponse
+from dacli.structure_index import StructureIndex
+
+# Global index reference - set by create_app, used by all routers
+_index: StructureIndex | None = None
+
+
+def set_index(index: StructureIndex) -> None:
+    """Set the global structure index.
+
+    Args:
+        index: The StructureIndex to use for all API operations.
+    """
+    global _index
+    _index = index
+
+
+def get_index() -> StructureIndex:
+    """Get the global structure index.
+
+    Returns:
+        The configured StructureIndex.
+
+    Raises:
+        HTTPException: If the index has not been initialized (503 status).
+    """
+    if _index is None:
+        raise HTTPException(
+            status_code=503,
+            detail=ErrorResponse(
+                error=ErrorDetail(
+                    code="INDEX_NOT_READY",
+                    message="Server index is not initialized",
+                )
+            ).model_dump(),
+        )
+    return _index

--- a/src/dacli/api/manipulation.py
+++ b/src/dacli/api/manipulation.py
@@ -9,8 +9,8 @@ from pathlib import Path as FilePath
 
 from fastapi import APIRouter, HTTPException, Path
 
+from dacli.api.dependencies import get_index
 from dacli.api.models import (
-    ErrorDetail,
     ErrorResponse,
     InsertContentRequest,
     InsertContentResponse,
@@ -20,36 +20,11 @@ from dacli.api.models import (
 )
 from dacli.file_handler import FileReadError, FileSystemHandler, FileWriteError
 from dacli.models import Section
-from dacli.structure_index import StructureIndex
 
 router = APIRouter(prefix="/api/v1", tags=["Manipulation"])
 
-# Global index reference - will be set by create_app
-_index: StructureIndex | None = None
-
 # File handler for atomic operations
 _file_handler: FileSystemHandler = FileSystemHandler()
-
-
-def set_index(index: StructureIndex) -> None:
-    """Set the global structure index."""
-    global _index
-    _index = index
-
-
-def get_index() -> StructureIndex:
-    """Get the global structure index."""
-    if _index is None:
-        raise HTTPException(
-            status_code=503,
-            detail=ErrorResponse(
-                error=ErrorDetail(
-                    code="INDEX_NOT_READY",
-                    message="Server index is not initialized",
-                )
-            ).model_dump(),
-        )
-    return _index
 
 
 def _get_section_end_line(section: Section, file_path: FilePath) -> int:

--- a/src/dacli/api/navigation.py
+++ b/src/dacli/api/navigation.py
@@ -8,8 +8,8 @@ Provides endpoints for navigating the document structure:
 
 from fastapi import APIRouter, HTTPException, Path, Query
 
+from dacli.api.dependencies import get_index
 from dacli.api.models import (
-    ErrorDetail,
     ErrorResponse,
     LocationResponse,
     SectionDetailResponse,
@@ -18,33 +18,8 @@ from dacli.api.models import (
     SectionSummary,
     StructureResponse,
 )
-from dacli.structure_index import StructureIndex
 
 router = APIRouter(prefix="/api/v1", tags=["Navigation"])
-
-# Global index reference - will be set by create_app
-_index: StructureIndex | None = None
-
-
-def set_index(index: StructureIndex) -> None:
-    """Set the global structure index."""
-    global _index
-    _index = index
-
-
-def get_index() -> StructureIndex:
-    """Get the global structure index."""
-    if _index is None:
-        raise HTTPException(
-            status_code=503,
-            detail=ErrorResponse(
-                error=ErrorDetail(
-                    code="INDEX_NOT_READY",
-                    message="Server index is not initialized",
-                )
-            ).model_dump(),
-        )
-    return _index
 
 
 @router.get(


### PR DESCRIPTION
## Summary

- Creates `api/dependencies.py` with shared `get_index()` and `set_index()` functions
- Removes duplicated code from `navigation.py`, `content.py`, `manipulation.py`
- Simplifies `app.py` to use single `dependencies.set_index()` call

## Changes

### New file: `api/dependencies.py`
- Shared `_index` state
- `set_index()` - called once during app initialization
- `get_index()` - used by all routers

### Removed from each module:
```python
_index: StructureIndex | None = None

def set_index(index: StructureIndex) -> None: ...
def get_index() -> StructureIndex: ...
```

### Simplified `app.py`:
```python
# Before
navigation.set_index(index)
content.set_index(index)
manipulation.set_index(index)

# After
dependencies.set_index(index)
```

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| Lines of code | 82 | 51 |
| `set_index()` definitions | 3 | 1 |
| `get_index()` definitions | 3 | 1 |

## Acceptance Criteria

- [x] Create `api/dependencies.py`
- [x] Remove duplicated code from navigation.py, content.py, manipulation.py
- [x] All 435 tests pass
- [x] No behavior changes

## Test plan

- [x] All 58 API tests pass
- [x] All 435 tests pass
- [x] `ruff check` passes

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)