### PR TITLE
fix: Add recursive parameter to API get_elements endpoint (Issue #155)

### DIFF
--- a/src/dacli/api/content.py
+++ b/src/dacli/api/content.py
@@ -118,6 +118,10 @@ def get_elements(
         default=None,
         description="Optional section path to filter elements",
     ),
+    recursive: bool = Query(
+        default=False,
+        description="Include elements from child sections (requires path)",
+    ),
 ) -> ElementsResponse:
     """Get elements filtered by type and optionally by section path."""
     # Validate element type
@@ -146,6 +150,7 @@ def get_elements(
         elements = index.get_elements(
             element_type=internal_type,
             section_path=path,
+            recursive=recursive,
         )
         all_elements.extend(elements)
 


### PR DESCRIPTION
## Summary

Adds the missing `recursive` query parameter to the FastAPI `GET /elements` endpoint.

## Changes

```python
# Before
def get_elements(type, path) -> ElementsResponse:

# After  
def get_elements(type, path, recursive=False) -> ElementsResponse:
```

## API Usage

```bash
# Without recursive (default) - exact section match
GET /elements?type=code&path=doc:section

# With recursive - includes child sections
GET /elements?type=code&path=doc:section&recursive=true
```

## Test Plan

- [x] All 454 tests pass
- [x] Linting passes
- [x] Logic already tested via CLI/MCP tests (same `index.get_elements()`)

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/code)