### PR TITLE
refactor: Extract shared business logic to Service Layer (Issue #163)

### DIFF
--- a/src/dacli/services/__init__.py
+++ b/src/dacli/services/__init__.py
@@ -1,0 +1,17 @@
+"""Service layer for dacli business logic.
+
+This module provides shared services used by both CLI and MCP interfaces.
+Services accept dependencies (index, file_handler) and return dict results.
+"""
+
+from dacli.services.content_service import compute_hash, update_section
+from dacli.services.metadata_service import get_project_metadata, get_section_metadata
+from dacli.services.validation_service import validate_structure
+
+__all__ = [
+    "get_project_metadata",
+    "get_section_metadata",
+    "validate_structure",
+    "update_section",
+    "compute_hash",
+]

--- a/src/dacli/services/content_service.py
+++ b/src/dacli/services/content_service.py
@@ -1,0 +1,168 @@
+"""Content service for section updates.
+
+Provides shared logic for CLI and MCP content manipulation operations.
+"""
+
+import hashlib
+from pathlib import Path
+
+from dacli.file_handler import FileReadError, FileSystemHandler, FileWriteError
+from dacli.structure_index import StructureIndex
+
+
+def compute_hash(content: str) -> str:
+    """Compute MD5 hash (first 8 chars) for optimistic locking.
+
+    Args:
+        content: The content to hash.
+
+    Returns:
+        First 8 characters of MD5 hex digest.
+    """
+    return hashlib.md5(content.encode("utf-8")).hexdigest()[:8]
+
+
+def _get_section_end_line(
+    section, file_path: Path, file_handler: FileSystemHandler
+) -> int:
+    """Get the end line of a section.
+
+    If the section has an end_line in source_location, use that.
+    Otherwise, calculate based on next section or file length.
+
+    Args:
+        section: The section object.
+        file_path: Path to the file.
+        file_handler: File system handler.
+
+    Returns:
+        The line number where the section ends.
+    """
+    # Use end_line if available
+    if section.source_location.end_line is not None:
+        return section.source_location.end_line
+
+    # Fallback: read file and calculate
+    try:
+        content = file_handler.read_file(file_path)
+        total_lines = len(content.splitlines())
+        return total_lines
+    except FileReadError:
+        return section.source_location.line
+
+
+def update_section(
+    index: StructureIndex,
+    file_handler: FileSystemHandler,
+    path: str,
+    content: str,
+    preserve_title: bool = True,
+    expected_hash: str | None = None,
+) -> dict:
+    """Update the content of a section.
+
+    Args:
+        index: The structure index.
+        file_handler: File system handler for I/O.
+        path: Hierarchical path to the section.
+        content: New section content.
+        preserve_title: Whether to preserve the original section title.
+        expected_hash: Optional hash for optimistic locking.
+
+    Returns:
+        Dictionary with:
+        - success: True if update succeeded
+        - path: The normalized section path
+        - location: dict with file and line
+        - previous_hash: Hash before update
+        - new_hash: Hash after update
+
+        Or error dict if failed:
+        - success: False
+        - error: Error message
+        - current_hash: (optional) Current hash if conflict
+    """
+    normalized_path = path.lstrip("/")
+
+    section = index.get_section(normalized_path)
+    if section is None:
+        return {"success": False, "error": f"Section '{normalized_path}' not found"}
+
+    file_path = section.source_location.file
+    start_line = section.source_location.line
+    end_line = _get_section_end_line(section, file_path, file_handler)
+
+    # Read current content and compute hash for optimistic locking
+    try:
+        file_content = file_handler.read_file(file_path)
+        lines = file_content.splitlines(keepends=True)
+        current_content = "".join(lines[start_line - 1 : end_line])
+        previous_hash = compute_hash(current_content)
+    except FileReadError:
+        previous_hash = ""
+
+    # Check for conflict if expected_hash is provided
+    if expected_hash is not None and expected_hash != previous_hash:
+        return {
+            "success": False,
+            "error": (
+                f"Hash conflict: expected '{expected_hash}', "
+                f"but current is '{previous_hash}'"
+            ),
+            "current_hash": previous_hash,
+        }
+
+    # Prepare content
+    new_content = content
+    if preserve_title:
+        stripped_content = new_content.lstrip()
+        has_explicit_title = (
+            stripped_content.startswith("=") or stripped_content.startswith("#")
+        )
+
+        # If content has a heading, strip it (we always use the original title)
+        if has_explicit_title:
+            content_lines = stripped_content.split("\n", 1)
+            if len(content_lines) > 1:
+                # Keep content after heading, strip leading newlines
+                new_content = content_lines[1].lstrip("\n")
+            else:
+                new_content = ""  # Content was just the heading
+
+        # Always prepend the original title when preserve_title is True
+        file_ext = file_path.suffix.lower()
+        if file_ext in (".adoc", ".asciidoc"):
+            # AsciiDoc: level 0 = "=", level 1 = "==", etc.
+            level_markers = "=" * (section.level + 1)
+        else:
+            # Markdown: level 1 = "#", level 2 = "##", etc.
+            level_markers = "#" * section.level
+        new_content = f"{level_markers} {section.title}\n\n{new_content}"
+
+    # Ensure content ends with newline
+    if not new_content.endswith("\n"):
+        new_content += "\n"
+
+    # Compute new hash
+    new_hash = compute_hash(new_content)
+
+    # Perform update
+    try:
+        file_handler.update_section(
+            path=file_path,
+            start_line=start_line,
+            end_line=end_line,
+            new_content=new_content,
+        )
+        return {
+            "success": True,
+            "path": normalized_path,
+            "location": {
+                "file": str(file_path),
+                "line": start_line,
+            },
+            "previous_hash": previous_hash,
+            "new_hash": new_hash,
+        }
+    except FileWriteError as e:
+        return {"success": False, "error": str(e)}

--- a/src/dacli/services/metadata_service.py
+++ b/src/dacli/services/metadata_service.py
@@ -1,0 +1,111 @@
+"""Metadata service for project and section metadata.
+
+Provides shared logic for CLI and MCP metadata operations.
+"""
+
+from datetime import UTC, datetime
+
+from dacli.structure_index import StructureIndex
+
+
+def get_project_metadata(index: StructureIndex) -> dict:
+    """Get project-level metadata.
+
+    Args:
+        index: The structure index to query.
+
+    Returns:
+        Dictionary with:
+        - path: None (indicates project-level)
+        - total_files: Number of documentation files
+        - total_sections: Total section count
+        - total_words: Approximate word count
+        - last_modified: ISO timestamp of most recent change
+        - formats: List of document formats (asciidoc, markdown)
+    """
+    stats = index.stats()
+    files = set(index._file_to_sections.keys())
+
+    # Calculate total words from all section content
+    total_words = 0
+    for content in index._section_content.values():
+        total_words += len(content.split())
+
+    # Find latest modification time
+    last_modified = None
+    for file_path in files:
+        if file_path.exists():
+            mtime = file_path.stat().st_mtime
+            if last_modified is None or mtime > last_modified:
+                last_modified = mtime
+
+    # Detect formats from file extensions
+    formats = set()
+    for file_path in files:
+        ext = file_path.suffix.lower()
+        if ext == ".adoc":
+            formats.add("asciidoc")
+        elif ext == ".md":
+            formats.add("markdown")
+
+    return {
+        "path": None,
+        "total_files": len(files),
+        "total_sections": stats["total_sections"],
+        "total_words": total_words,
+        "last_modified": (
+            datetime.fromtimestamp(last_modified, tz=UTC).isoformat()
+            if last_modified
+            else None
+        ),
+        "formats": sorted(formats),
+    }
+
+
+def get_section_metadata(index: StructureIndex, path: str) -> dict:
+    """Get section-level metadata.
+
+    Args:
+        index: The structure index to query.
+        path: Hierarchical path to the section.
+
+    Returns:
+        Dictionary with:
+        - path: The normalized section path
+        - title: Section title
+        - file: Source file path
+        - word_count: Word count in section
+        - last_modified: ISO timestamp of file modification
+        - subsection_count: Number of direct children
+
+        Or error dict if section not found:
+        - error: Error message
+    """
+    normalized_path = path.lstrip("/")
+    section = index.get_section(normalized_path)
+
+    if section is None:
+        return {"error": f"Section '{normalized_path}' not found"}
+
+    # Get word count from section content
+    content = index._section_content.get(normalized_path, "")
+    word_count = len(content.split())
+
+    # Get file modification time
+    file_path = section.source_location.file
+    last_modified = None
+    if file_path.exists():
+        mtime = file_path.stat().st_mtime
+        last_modified = datetime.fromtimestamp(mtime, tz=UTC).isoformat()
+
+    # Count subsections
+    subsection_count = len(section.children)
+
+    return {
+        "path": normalized_path,
+        "title": section.title,
+        "file": str(file_path),
+        "word_count": word_count,
+        "last_modified": last_modified,
+        "subsection_count": subsection_count,
+    }

--- a/src/dacli/services/validation_service.py
+++ b/src/dacli/services/validation_service.py
@@ -1,0 +1,82 @@
+"""Validation service for document structure validation.
+
+Provides shared logic for CLI and MCP validation operations.
+"""
+
+import time
+from pathlib import Path
+
+from dacli.file_utils import find_doc_files
+from dacli.structure_index import StructureIndex
+
+
+def validate_structure(index: StructureIndex, docs_root: Path) -> dict:
+    """Validate the document structure.
+
+    Checks for:
+    - Orphaned files (not included in any document)
+    - Parse warnings (unclosed blocks, tables)
+
+    Args:
+        index: The structure index to validate.
+        docs_root: Root directory of documentation.
+
+    Returns:
+        Dictionary with:
+        - valid: True if no errors, False otherwise
+        - errors: List of error objects
+        - warnings: List of warning objects
+        - validation_time_ms: Time taken for validation
+    """
+    start_time = time.time()
+
+    errors: list[dict] = []
+    warnings: list[dict] = []
+
+    # Get all indexed files
+    indexed_files = set(index._file_to_sections.keys())
+
+    # Get all doc files in docs_root (respecting gitignore)
+    all_doc_files: set[Path] = set()
+    for adoc_file in find_doc_files(docs_root, "*.adoc"):
+        all_doc_files.add(adoc_file.resolve())
+    for md_file in find_doc_files(docs_root, "*.md"):
+        all_doc_files.add(md_file.resolve())
+
+    # Check for orphaned files (files not indexed)
+    indexed_resolved = {f.resolve() for f in indexed_files}
+    docs_root_resolved = docs_root.resolve()
+    for doc_file in all_doc_files:
+        if doc_file not in indexed_resolved:
+            try:
+                rel_path = doc_file.relative_to(docs_root_resolved)
+            except ValueError:
+                rel_path = doc_file
+            warnings.append({
+                "type": "orphaned_file",
+                "path": str(rel_path),
+                "message": "File is not included in any document",
+            })
+
+    # Collect parse warnings from all documents (Issue #148)
+    for doc in index._documents:
+        for pw in doc.parse_warnings:
+            try:
+                rel_path = pw.file.relative_to(docs_root_resolved)
+            except ValueError:
+                rel_path = pw.file
+            warnings.append({
+                "type": pw.type.value,
+                "path": f"{rel_path}:{pw.line}",
+                "message": pw.message,
+            })
+
+    # Calculate validation time
+    elapsed_ms = int((time.time() - start_time) * 1000)
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "validation_time_ms": elapsed_ms,
+    }


### PR DESCRIPTION
## Summary
Introduces a Service Layer to eliminate code duplication between CLI and MCP:

- **MetadataService**: `get_project_metadata()`, `get_section_metadata()`
- **ValidationService**: `validate_structure()`
- **ContentService**: `update_section()`, `compute_hash()`

## Changes
- New: `src/dacli/services/` package with 4 files (378 lines)
- Modified: `cli.py` (859 → 696 lines, -19%)
- Modified: `mcp_app.py` (726 → 530 lines, -27%)

## Benefits
- Single source of truth for business logic
- CLI and MCP automatically stay in sync
- Easier testing (services can be tested independently)
- Clearer separation of concerns

## Test Plan
- [x] All 456 existing tests pass
- [x] No behavior changes (pure refactoring)
- [x] Linting passes

Fixes #163

🤖 Generated with [Claude Code](https://claude.ai/claude-code)