### PR TITLE
feat: Add --limit alias and change default to 20 results (Issue #177)

### DIFF
--- a/src/dacli/api/models.py
+++ b/src/dacli/api/models.py
@@ -87,7 +87,7 @@ class SearchRequest(BaseModel):
     query: str = Field(min_length=1, description="Search query string")
     scope: str | None = Field(default=None, description="Restrict search to path prefix")
     case_sensitive: bool = Field(default=False, description="Case-sensitive search")
-    max_results: int = Field(default=50, ge=1, le=1000, description="Maximum results")
+    max_results: int = Field(default=20, ge=1, le=1000, description="Maximum results (default: 20)")
 
 
 class SearchResultItem(BaseModel):

--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -439,12 +439,15 @@ def sections_at_level(ctx: CliContext, level: int):
 Examples:
   dacli search "authentication"              # Search all docs
   dacli search "API" --scope api             # Search within 'api' section
-  dacli search "error" --max-results 5       # Limit results
+  dacli search "error" --limit 5             # Limit results
   dacli --format json s "database"           # JSON output using alias
 """)
 @click.argument("query")
 @click.option("--scope", default=None, help="Path prefix to limit search scope")
-@click.option("--max-results", type=int, default=50, help="Maximum results to return")
+@click.option(
+    "--max-results", "--limit", type=int, default=20,
+    help="Maximum results to return (default: 20)"
+)
 @pass_context
 def search(ctx: CliContext, query: str, scope: str | None, max_results: int):
     """Search for content in the documentation."""

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -224,7 +224,7 @@ def create_mcp_server(
     def search(
         query: str,
         scope: str | None = None,
-        max_results: int = 50,
+        max_results: int = 20,
     ) -> dict:
         """Search for content in the documentation.
 
@@ -235,7 +235,7 @@ def create_mcp_server(
             query: Search query string (case-insensitive by default).
             scope: Optional path prefix to limit search scope
                    (e.g., '/architecture' to search only in that section).
-            max_results: Maximum number of results to return (default: 50).
+            max_results: Maximum number of results to return (default: 20).
 
         Returns:
             Search results with 'query', 'results' (list of matches with

--- a/src/dacli/structure_index.py
+++ b/src/dacli/structure_index.py
@@ -350,7 +350,7 @@ class StructureIndex:
         query: str,
         scope: str | None = None,
         case_sensitive: bool = False,
-        max_results: int = 50,
+        max_results: int = 20,
     ) -> list[SearchResult]:
         """Search for content matching query.
 
@@ -360,7 +360,7 @@ class StructureIndex:
             query: Search query string
             scope: Optional path prefix to limit search scope
             case_sensitive: Whether search is case-sensitive
-            max_results: Maximum number of results to return
+            max_results: Maximum number of results to return (default: 20)
 
         Returns:
             List of SearchResult objects

--- a/src/docs/spec/02_api_specification.adoc
+++ b/src/docs/spec/02_api_specification.adoc
@@ -345,7 +345,7 @@ Searches documentation content.
 | Restriction to path prefix (e.g., "/architecture")
 
 | `max_results` (int, optional)
-| Maximum results to return (default: 50)
+| Maximum results to return (default: 20)
 |===
 
 **Response 200:**

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -154,13 +154,18 @@ Searches the documentation.
 
 [source,bash]
 ----
-dacli search <QUERY> [--scope PATH] [--max-results N]
+dacli search <QUERY> [--scope PATH] [--max-results N] [--limit N]
 ----
+
+**Options:**
+
+* `--max-results N`, `--limit N`: Maximum results to return (default: 20, aliases)
+* `--scope PATH`: Restrict search to path prefix
 
 **Example:**
 [source,bash]
 ----
-$ dacli search "authentication" --max-results 5
+$ dacli search "authentication" --limit 5
 {
   "query": "authentication",
   "results": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,6 +280,40 @@ This section covers authentication topics.
         assert "query" in data
         assert "results" in data
 
+    def test_search_limit_alias_works(self, sample_docs):
+        """--limit should work as alias for --max-results."""
+        from dacli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--docs-root", str(sample_docs), "--format", "json",
+                "search", "authentication", "--limit", "1"
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["results"]) <= 1
+
+    def test_search_max_results_still_works(self, sample_docs):
+        """--max-results should still work (backward compatibility)."""
+        from dacli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--docs-root", str(sample_docs), "--format", "json",
+                "search", "authentication", "--max-results", "1"
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["results"]) <= 1
+
 
 class TestCliMetadataCommand:
     """Test the 'metadata' command."""


### PR DESCRIPTION
## Summary

Adds `--limit` as a shorter alias for `--max-results` and changes the default from 50 to 20 for better user experience with large documentation sets.

## Changes

### CLI (`src/dacli/cli.py`)
- Add `--limit` as alias: `@click.option("--max-results", "--limit", ...)`
- Change default from 50 to 20
- Update example in epilog to use `--limit`

### MCP (`src/dacli/mcp_app.py`)
- Change `search` tool default from 50 to 20
- Update docstring

### FastAPI (`src/dacli/api/models.py`)
- Change `SearchRequest.max_results` default from 50 to 20

### Core (`src/dacli/structure_index.py`)
- Change `StructureIndex.search()` default from 50 to 20

### Documentation
- **02_api_specification.adoc**: Update default to 20
- **06_cli_specification.adoc**: Document `--limit` alias, update examples

## Usage Examples

**Using the new --limit alias:**
```bash
$ dacli search "authentication" --limit 5
```

**Backward compatible:**
```bash
$ dacli search "authentication" --max-results 5  # Still works
```

**New default:**
```bash
$ dacli search "authentication"  # Returns max 20 results (was 50)
```

## Test Results

Added tests for:
- `test_search_limit_alias_works` - Verifies `--limit` works
- `test_search_max_results_still_works` - Backward compatibility

All 103 tests passing.

## Breaking Change Note

⚠️ **Minor Breaking Change**: Default changed from 50 to 20 results. Users relying on the old default can explicitly use `--max-results 50` or `--limit 50`.

Fixes #177

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)