### PR TITLE
fix: Remove --section parameter from elements command (Issue #178)

### DIFF
--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -476,23 +476,18 @@ Examples:
   dacli elements --type code             # Only code blocks
   dacli elements --type table            # Only tables
   dacli elements api                     # Elements in 'api' section
-  dacli elements --section api           # Same as above (--section still works)
   dacli elements api --recursive         # Elements in 'api' and all subsections
   dacli --format json el --type image    # JSON output using alias
 """)
-@click.argument("section_path_arg", required=False, default=None)
+@click.argument("section_path", required=False, default=None)
 @click.option("--type", "element_type", default=None,
               help="Element type: code, table, image, diagram, list")
-@click.option("--section", "section_path_opt", default=None,
-              help="Filter by section path (alternative to positional argument)")
 @click.option("--recursive", is_flag=True, default=False,
               help="Include elements from child sections")
 @pass_context
-def elements(ctx: CliContext, section_path_arg: str | None, element_type: str | None,
-             section_path_opt: str | None, recursive: bool):
+def elements(ctx: CliContext, section_path: str | None, element_type: str | None,
+             recursive: bool):
     """Get elements (code blocks, tables, images) from documentation."""
-    # Use positional argument if provided, otherwise fall back to --section option
-    section_path = section_path_arg or section_path_opt
     elems = ctx.index.get_elements(
         element_type=element_type,
         section_path=section_path,

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -176,16 +176,16 @@ Lists elements (code blocks, tables, etc.).
 
 [source,bash]
 ----
-dacli elements [SECTION_PATH] [--type TYPE] [--section PATH] [--recursive]
+dacli elements [SECTION_PATH] [--type TYPE] [--recursive]
 ----
 
-The section path can be provided as a positional argument or via the `--section` option.
-Both forms are equivalent: `dacli elements api` and `dacli elements --section api`.
+**Arguments:**
+
+* `SECTION_PATH`: Optional section path to filter elements (positional argument)
 
 **Options:**
 
 * `--type TYPE`: Element type filter - `code`, `table`, `image`, `diagram`, `list`, `admonition`
-* `--section PATH`: Filter by section path (alternative to positional argument)
 * `--recursive`: Include elements from child sections (default: exact match only)
 
 == Meta-Information Commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1543,33 +1543,6 @@ print("hello")
         assert data["count"] == 1
         assert data["elements"][0]["type"] == "code"
 
-    def test_elements_section_option_still_works(self, tmp_path):
-        """--section option should still work for backward compatibility."""
-        from dacli.cli import cli
-
-        doc_file = tmp_path / "test.adoc"
-        doc_file.write_text("""= Test Document
-
-== Code Section
-
-[source,python]
-----
-print("hello")
-----
-""")
-
-        runner = CliRunner()
-        # Section path includes document prefix: "test:code-section"
-        result = runner.invoke(
-            cli,
-            ["--docs-root", str(tmp_path), "--format", "json", "elements",
-             "--section", "test:code-section"],
-        )
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["count"] == 1
-
     def test_elements_positional_and_type_option_combined(self, tmp_path):
         """dacli elements --type TYPE PATH should work."""
         from dacli.cli import cli
@@ -1632,7 +1605,7 @@ print("in child")
         result = runner.invoke(
             cli,
             ["--docs-root", str(tmp_path), "--format", "json", "elements",
-             "--section", "test:parent-section"],
+             "test:parent-section"],
         )
 
         assert result.exit_code == 0
@@ -1664,7 +1637,7 @@ print("in child")
         result = runner.invoke(
             cli,
             ["--docs-root", str(tmp_path), "--format", "json", "elements",
-             "--section", "test:parent-section", "--recursive"],
+             "test:parent-section", "--recursive"],
         )
 
         assert result.exit_code == 0
@@ -1701,7 +1674,7 @@ level 3 code
         result = runner.invoke(
             cli,
             ["--docs-root", str(tmp_path), "--format", "json", "elements",
-             "--section", "test:level-1", "--recursive"],
+             "test:level-1", "--recursive"],
         )
 
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Removes the confusing and buggy `--section` option from the `elements` command, keeping only the positional argument approach which is more idiomatic for CLI tools.

## Problem

The `--section` option was:
- Not working correctly (returned 0 results)
- Redundant (positional argument works fine)
- Confusing (two ways to do the same thing)

## Changes

### CLI (`src/dacli/cli.py`)
**Before:**
```python
@click.argument("section_path_arg", required=False, default=None)
@click.option("--section", "section_path_opt", default=None)
def elements(ctx, section_path_arg, element_type, section_path_opt, recursive):
    section_path = section_path_arg or section_path_opt  # Fallback logic
```

**After:**
```python
@click.argument("section_path", required=False, default=None)
def elements(ctx, section_path, element_type, recursive):
    # Direct usage, no fallback needed
```

### Specification (`src/docs/spec/06_cli_specification.adoc`)
- Removed `--section PATH` from usage and options
- Clarified that section path is a positional argument

### Tests (`tests/test_cli.py`)
- Removed `test_elements_section_option_still_works` test
- Updated 3 tests to use positional argument instead of `--section`

## Migration

Users currently using:
```bash
dacli elements --section api
```

Should change to:
```bash
dacli elements api
```

## Test Results

All 100 tests passing, including:
- `test_elements_accepts_section_as_positional_argument`
- `test_elements_without_section_filters`
- `test_elements_with_recursive_includes_children`
- `test_elements_recursive_with_multiple_levels`

Fixes #178

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)