### PR TITLE
fix: Skip Claude Code actions on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
+    # Skip for PRs from forks (no access to secrets)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # Optional: Additional filter by PR author
     # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #   github.event.pull_request.head.repo.full_name == github.repository &&
+    #   (github.event.pull_request.user.login == 'external-contributor' ||
+    #    github.event.pull_request.user.login == 'new-developer' ||
+    #    github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,17 @@ on:
 
 jobs:
   claude:
+    # Skip PR-related events from forks (no access to secrets)
+    # Note: issue_comment on fork PRs will still trigger but fail gracefully
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Prevents Claude Code GitHub Actions from running on pull requests from forks, where they would fail due to missing `ANTHROPIC_API_KEY` secret.

## Problem

When external contributors create PRs from forks:
- Forks don't have access to repository secrets
- Claude Code actions fail with authentication errors
- Creates noise in the CI/CD pipeline

## Changes

### claude-code-review.yml
Added condition to skip entirely for fork PRs:
```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

### claude.yml
Added fork checks for PR-related events:
- `pull_request_review_comment`: Skip if from fork
- `pull_request_review`: Skip if from fork
- `issue_comment`: Allow (will fail gracefully if on fork PR, but we can't detect that easily)
- `issues`: Allow (not fork-specific)

## Behavior

**Before:**
- Fork PRs → Claude actions run → Fail with authentication error

**After:**
- Fork PRs → Claude actions skipped
- Same-repo PRs → Claude actions run normally
- Regular issues → Claude actions run normally

## Testing

This will be automatically tested when:
1. A fork PR is created (actions should be skipped)
2. A same-repo PR is created (actions should run)

## Notes

- `issue_comment` events on fork PRs will still trigger but fail gracefully (acceptable trade-off, as we can't easily detect fork status for issue comments)
- This follows GitHub Actions best practices for handling fork PRs with secrets

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)