### PR TITLE
chore: Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary

Bump version from 0.3.x to 0.4.0 to reflect recent feature additions and changes.

## Changes

This version includes the following changes merged since 0.3.0:

- **feat**: Add `--limit` alias for `--max-results` (Issue #177)
- **feat**: Change default max results from 50 to 20 (Issue #177)
- **fix**: Remove `--section` parameter from elements command (Issue #178)
- **fix**: Reject empty search queries with validation (Issue #175)

## Version Updates

- `pyproject.toml`: 0.3.0 → 0.4.0
- `src/dacli/__init__.py`: 0.3.2 → 0.4.0

## Semantic Versioning Rationale

Minor version bump (0.3.x → 0.4.0) because:
- New feature: `--limit` alias
- Breaking change: `--section` parameter removed (backward incompatible)
- Bug fix: Empty query validation

Closes #177, #178, #175