### PR TITLE
docs: Add fork synchronization step to workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,14 @@ Development happens on a fork to keep `upstream/main` stable for `uv tool instal
 5. Create PR from fork to `upstream/main` (use `Fixes #123` in PR body)
 6. CI runs on PR, review, then merge
 7. Issues auto-close when merged to main
+8. **After merge:** Sync fork main with upstream to prevent duplicates:
+   ```bash
+   git checkout main
+   git reset --hard upstream/main
+   git push origin main --force-with-lease
+   ```
+
+**IMPORTANT:** Always create feature branches from `upstream/main`, never from fork `main`. This ensures clean, linear history and avoids duplicate commits.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Documents the fork synchronization step that should be performed after each PR merge to prevent duplicate commits and merge conflicts.

### Changes

- Added step 8 to workflow: Sync fork main with upstream/main after merge
- Added important note: Always create feature branches from `upstream/main`, not from fork `main`

### Why This Matters

Without fork synchronization:
- Fork main diverges from upstream/main with duplicate commits (same changes, different hashes)
- Future PRs contain commits already merged to upstream
- Git history becomes messy with merge conflicts
- "This branch cannot be rebased" errors occur

With proper synchronization:
- Fork main stays in sync with upstream/main
- Feature branches have clean, linear history
- PRs only contain relevant new changes
- Git workflow stays clean and predictable

### Example

This PR follows the new workflow:
1. Created from `upstream/main` (not fork main)
2. Contains only the documentation change
3. After merge, fork main will be synchronized

🤖 Generated with [Claude Code](https://claude.com/claude-code)