### PR TITLE
fix: Add workflow permissions and commit test badge

### DIFF
--- a/.github/coverage-badge.svg
+++ b/.github/coverage-badge.svg
@@ -1,1 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="108" height="20" role="img" aria-label="coverage: 90.7%"><title>coverage: 90.7%</title><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="108" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#r)"><rect width="61" height="20" fill="#555"/><rect x="61" width="47" height="20" fill="#4c1"/><rect width="108" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text><text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text><text aria-hidden="true" x="835" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">90.7%</text><text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="370">90.7%</text></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
+        <text x="80" y="14">91%</text>
+    </g>
+</svg>

--- a/.github/tests-badge.svg
+++ b/.github/tests-badge.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="88" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <path fill="#555" d="M0 0h41v20H0z"/>
+    <path fill="#007ec6" d="M41 0h47v20H41z"/>
+    <path fill="url(#b)" d="M0 0h88v20H0z"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="20.5" y="15" fill="#010101" fill-opacity=".3">tests</text>
+    <text x="20.5" y="14">tests</text>
+    <text x="64.5" y="15" fill="#010101" fill-opacity=".3">553</text>
+    <text x="64.5" y="14">553</text>
+  </g>
+</svg>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Allow pushing badge updates
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.8"
+version = "0.4.9"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Follow-up fix for #210 - Adds missing write permissions and commits the test badge file.

## Problem
After merging PR #212, the badges were generated successfully but the push failed:
```
remote: Permission to docToolchain/dacli.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/docToolchain/dacli/': The requested URL returned error: 403
```

This caused:
- `tests-badge.svg` was never committed to the repository
- README shows broken badge reference for test count
- Badges can't auto-update on subsequent runs

## Root Cause
The workflow lacked `contents: write` permission for the GITHUB_TOKEN, preventing `github-actions[bot]` from pushing badge updates.

## Solution

1. **Add Workflow Permissions:**
   ```yaml
   permissions:
     contents: write  # Allow pushing badge updates
   ```

2. **Commit Missing Badge:**
   - Generated `tests-badge.svg` locally (553 tests)
   - Updated `coverage-badge.svg` with current coverage (90.7%)
   - Committed both to repository

## Changes
- `.github/workflows/test.yml`: Add `permissions: contents: write`
- `.github/tests-badge.svg`: New file (test count badge)
- `.github/coverage-badge.svg`: Updated with latest coverage
- Version bumped to 0.4.9

## Testing
- Badges generated locally: ✅
- Files committed to repo: ✅  
- Ready for automatic updates on next CI run

## Result
After merge:
- Both badges will display correctly in README
- Future test runs will automatically update badges
- No more permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)