### PR TITLE
fix: get_structure max_depth now correctly includes depth N (#218)

### DIFF
--- a/.vibe/development-plan-fix-max-depth-off-by-one-218.md
+++ b/.vibe/development-plan-fix-max-depth-off-by-one-218.md
@@ -1,0 +1,87 @@
+# Development Plan: Fix #218 - get_structure max_depth off-by-one
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+Fix the off-by-one error in get_structure's max_depth parameter so that max_depth=N shows sections up to depth N (not N-1).
+
+## Key Decisions
+- Change condition from `current_depth < max_depth` to `current_depth <= max_depth`
+- This maintains max_depth=0 showing only root (no children)
+
+## Notes
+- Issue: https://github.com/docToolchain/dacli/issues/218
+- Branch: fix/max-depth-off-by-one-218
+- Root cause already identified in issue: condition `current_depth < max_depth` should be `<=`
+
+## Reproduce
+
+### Phase Entrance Criteria:
+- [x] Issue #218 has been reviewed and understood
+
+### Tasks
+- [ ] Create test document with nested sections
+- [ ] Call get_structure with different max_depth values
+- [ ] Verify off-by-one behavior
+
+### Completed
+- [x] Created development plan file
+
+## Analyze
+
+### Phase Entrance Criteria:
+- [ ] Bug has been successfully reproduced
+- [ ] Steps to reproduce are documented
+
+### Tasks
+- [ ] Verify root cause in structure_index.py
+- [ ] Check if CLI has same issue
+
+### Completed
+*None yet*
+
+## Fix
+
+### Phase Entrance Criteria:
+- [ ] Root cause verified
+- [ ] Solution approach confirmed
+
+### Tasks
+- [ ] Write failing test
+- [ ] Change `<` to `<=` in _section_to_dict
+- [ ] Verify existing tests pass
+
+### Completed
+*None yet*
+
+## Verify
+
+### Phase Entrance Criteria:
+- [ ] Fix implemented
+- [ ] All tests pass
+
+### Tasks
+- [ ] Run full test suite
+- [ ] Manual verification
+- [ ] Test edge cases
+
+### Completed
+*None yet*
+
+## Finalize
+
+### Phase Entrance Criteria:
+- [ ] All tests pass
+- [ ] No regressions
+
+### Tasks
+- [ ] Update version
+- [ ] Create commit
+- [ ] Create PR
+
+### Completed
+*None yet*
+
+---
+*This plan is maintained by the LLM.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.13"
+version = "0.4.14"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"

--- a/src/dacli/structure_index.py
+++ b/src/dacli/structure_index.py
@@ -639,7 +639,8 @@ class StructureIndex:
         }
 
         # Include children based on max_depth
-        if max_depth is None or current_depth < max_depth:
+        # Issue #218: Changed < to <= so max_depth=N shows depths 0..N
+        if max_depth is None or current_depth <= max_depth:
             result["children"] = [
                 self._section_to_dict(child, max_depth, current_depth + 1)
                 for child in section.children

--- a/tests/test_max_depth_off_by_one_218.py
+++ b/tests/test_max_depth_off_by_one_218.py
@@ -1,0 +1,122 @@
+"""Tests for Issue #218: get_structure max_depth off-by-one error.
+
+The max_depth parameter should include sections up to that depth,
+not depth-1.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from dacli.asciidoc_parser import AsciidocStructureParser
+from dacli.structure_index import StructureIndex
+
+
+@pytest.fixture
+def temp_nested_doc(tmp_path: Path) -> Path:
+    """Create a temporary directory with nested sections."""
+    doc_file = tmp_path / "test.adoc"
+    doc_file.write_text(
+        """= Document
+
+== Level 1 Section
+
+Content level 1.
+
+=== Level 2 Section
+
+Content level 2.
+
+==== Level 3 Section
+
+Content level 3.
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def index(temp_nested_doc: Path) -> StructureIndex:
+    """Build index from test document."""
+    parser = AsciidocStructureParser(base_path=temp_nested_doc)
+    index = StructureIndex()
+
+    documents = []
+    for doc_file in temp_nested_doc.glob("*.adoc"):
+        doc = parser.parse_file(doc_file)
+        documents.append(doc)
+
+    index.build_from_documents(documents)
+    return index
+
+
+def count_sections_by_depth(structure: dict, depth: int = 0) -> dict[int, int]:
+    """Count sections at each depth level."""
+    counts: dict[int, int] = {}
+
+    def count_recursive(items: list, current_depth: int):
+        for item in items:
+            counts[current_depth] = counts.get(current_depth, 0) + 1
+            if "children" in item:
+                count_recursive(item["children"], current_depth + 1)
+
+    if "documents" in structure:
+        count_recursive(structure["documents"], 0)
+    elif "sections" in structure:
+        count_recursive(structure["sections"], 0)
+
+    return counts
+
+
+class TestMaxDepthBehavior:
+    """Test that max_depth correctly limits section depth."""
+
+    def test_max_depth_0_shows_only_root(self, index: StructureIndex):
+        """max_depth=0 should show only the document root (no children)."""
+        structure = index.get_structure(max_depth=0)
+
+        counts = count_sections_by_depth(structure)
+        max_visible_depth = max(counts.keys()) if counts else -1
+
+        assert max_visible_depth == 0, (
+            f"max_depth=0 should show only depth 0. Counts: {counts}"
+        )
+
+    def test_max_depth_1_shows_root_and_children(self, index: StructureIndex):
+        """max_depth=1 should show root AND direct children (depth 0 and 1)."""
+        structure = index.get_structure(max_depth=1)
+
+        counts = count_sections_by_depth(structure)
+        max_visible_depth = max(counts.keys()) if counts else -1
+
+        # Issue #218: This was returning 0 instead of 1
+        assert max_visible_depth == 1, (
+            f"max_depth=1 should show depths 0 and 1. Counts: {counts}"
+        )
+        assert 1 in counts, f"Should have sections at depth 1. Counts: {counts}"
+
+    def test_max_depth_2_shows_three_levels(self, index: StructureIndex):
+        """max_depth=2 should show depths 0, 1, and 2."""
+        structure = index.get_structure(max_depth=2)
+
+        counts = count_sections_by_depth(structure)
+        max_visible_depth = max(counts.keys()) if counts else -1
+
+        # Issue #218: This was returning 1 instead of 2
+        assert max_visible_depth == 2, (
+            f"max_depth=2 should show depths 0, 1, and 2. Counts: {counts}"
+        )
+        assert 2 in counts, f"Should have sections at depth 2. Counts: {counts}"
+
+    def test_max_depth_none_shows_all(self, index: StructureIndex):
+        """max_depth=None should show all levels."""
+        structure = index.get_structure(max_depth=None)
+
+        counts = count_sections_by_depth(structure)
+        max_visible_depth = max(counts.keys()) if counts else -1
+
+        # Our test doc has 3 levels (0, 1, 2, 3 for doc + 3 section levels)
+        assert max_visible_depth >= 2, (
+            f"max_depth=None should show all levels. Counts: {counts}"
+        )

--- a/tests/test_navigation_api.py
+++ b/tests/test_navigation_api.py
@@ -119,29 +119,18 @@ class TestGetStructure:
         assert intro["children"][0]["path"] == "/introduction/goals"
 
     def test_get_structure_with_max_depth_1(self, client: TestClient):
-        """AC-NAV-02: max_depth=1 returns only level 1 sections."""
+        """Issue #218: max_depth=1 returns level 1 sections WITH their children."""
         response = client.get("/api/v1/structure?max_depth=1")
         data = response.json()
 
         assert response.status_code == 200
         assert len(data["sections"]) == 2
 
-        # Children should be empty due to max_depth
-        for section in data["sections"]:
-            assert section["children"] == []
-
-    def test_get_structure_with_max_depth_2(self, client: TestClient):
-        """max_depth=2 returns levels 1 and 2."""
-        response = client.get("/api/v1/structure?max_depth=2")
-        data = response.json()
-
-        assert response.status_code == 200
-
         # Level 1 sections should have children
         intro = data["sections"][0]
         assert len(intro["children"]) == 2
 
-        # Level 2 children should have empty children (no level 3)
+        # Level 2 children should have empty children (no level 3 at max_depth=1)
         for child in intro["children"]:
             assert child["children"] == []
 

--- a/tests/test_structure_index.py
+++ b/tests/test_structure_index.py
@@ -221,15 +221,21 @@ class TestGetStructure:
         )
         index.build_from_documents([doc])
 
-        # max_depth=1 should only return level 1 sections
-        structure = index.get_structure(max_depth=1)
+        # Issue #218: max_depth=0 returns only top-level (no children)
+        structure = index.get_structure(max_depth=0)
         assert len(structure["sections"]) == 1
         assert structure["sections"][0]["children"] == []
 
-        # max_depth=2 should return level 1 and 2
-        structure = index.get_structure(max_depth=2)
+        # max_depth=1 returns level 1 sections WITH their children (level 2)
+        structure = index.get_structure(max_depth=1)
+        assert len(structure["sections"]) == 1
         assert len(structure["sections"][0]["children"]) == 1
         assert structure["sections"][0]["children"][0]["children"] == []
+
+        # max_depth=2 returns levels 1, 2, and 3
+        structure = index.get_structure(max_depth=2)
+        assert len(structure["sections"][0]["children"]) == 1
+        assert len(structure["sections"][0]["children"][0]["children"]) == 1
 
 
 class TestGetSection:

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.13"
+version = "0.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Fixed off-by-one error in `max_depth` parameter
- `max_depth=N` now shows sections up to depth N (was N-1)

## Root Cause
In `structure_index.py:642`, the condition `current_depth < max_depth` excluded the final level. Changed to `current_depth <= max_depth`.

## Behavior Change
| max_depth | Before (wrong) | After (correct) |
|-----------|----------------|-----------------|
| 0 | Root only | Root only |
| 1 | Root only | Root + children |
| 2 | Root + children | Root + children + grandchildren |

## Test plan
- [x] Added 4 test cases in `tests/test_max_depth_off_by_one_218.py`
- [x] Updated existing tests to match correct behavior
- [x] All 568 tests pass
- [x] Linting passes

Fixes #218

🤖 Generated with [Claude Code](https://claude.ai/claude-code)