### PR TITLE
fix: MCP tools validate negative parameter values (#220)

### DIFF
--- a/.vibe/development-plan-fix-mcp-negative-params-validation-220.md
+++ b/.vibe/development-plan-fix-mcp-negative-params-validation-220.md
@@ -1,0 +1,89 @@
+# Development Plan: Issue #220 - MCP Negative Parameter Validation
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+*Branch: fix/mcp-negative-params-validation-220*
+
+## Goal
+Add validation to MCP tools to reject negative parameter values where only non-negative values make sense (max_results, max_depth, level, content_limit).
+
+## Affected Tools and Parameters
+| Tool | Parameter | Current Behavior |
+|------|-----------|-----------------|
+| `search` | `max_results` | -5 returns 8 results |
+| `get_structure` | `max_depth` | -1 returns structure with no children |
+| `get_sections_at_level` | `level` | -1 returns 0 sections |
+| `get_elements` | `content_limit` | No validation error |
+
+## Key Decisions
+*Important decisions will be documented here as they are made*
+
+## Notes
+*Additional context and observations*
+
+## Reproduce
+
+### Tasks
+- [ ] Write tests that show negative parameters are currently accepted without error
+- [ ] Verify current behavior matches issue description
+
+### Completed
+- [x] Created development plan file
+
+## Analyze
+
+### Phase Entrance Criteria
+- [ ] Bug has been reproduced with failing tests
+- [ ] Current behavior is documented
+
+### Tasks
+- [ ] Identify MCP tool definitions in codebase
+- [ ] Determine best validation approach (Pydantic Field validators vs manual checks)
+
+### Completed
+*None yet*
+
+## Fix
+
+### Phase Entrance Criteria
+- [ ] Root cause is identified
+- [ ] Validation approach is decided
+
+### Tasks
+- [ ] Add validation to reject negative values with clear error messages
+- [ ] Run tests to verify fix
+
+### Completed
+*None yet*
+
+## Verify
+
+### Phase Entrance Criteria
+- [ ] Fix is implemented
+- [ ] All new tests pass
+
+### Tasks
+- [ ] Run full test suite
+- [ ] Run linting
+- [ ] Bump version
+
+### Completed
+*None yet*
+
+## Finalize
+
+### Phase Entrance Criteria
+- [ ] All tests pass
+- [ ] Linting passes
+- [ ] Version bumped
+
+### Tasks
+- [ ] Commit changes
+- [ ] Push to fork
+- [ ] Create PR
+
+### Completed
+*None yet*
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.15"
+version = "0.4.16"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.15"
+__version__ = "0.4.16"

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -125,7 +125,13 @@ def create_mcp_server(
         Returns:
             Document structure with 'sections' (hierarchical tree) and
             'total_sections' count.
+
+        Raises:
+            ValueError: If max_depth is negative.
         """
+        # Issue #220: Validate max_depth
+        if max_depth is not None and max_depth < 0:
+            raise ValueError("max_depth must be non-negative")
         return index.get_structure(max_depth)
 
     @mcp.tool()
@@ -205,7 +211,13 @@ def create_mcp_server(
         Returns:
             Dictionary with 'level', 'sections' (list with path and title),
             and 'count'.
+
+        Raises:
+            ValueError: If level is not positive (levels are 1-based).
         """
+        # Issue #220: Validate level (must be >= 1, levels are 1-based)
+        if level < 1:
+            raise ValueError("level must be positive (1 = chapters, 2 = sections, etc.)")
         sections = index.get_sections_at_level(level)
 
         return {
@@ -247,6 +259,10 @@ def create_mcp_server(
         # Validate query is not empty
         if not query or not query.strip():
             raise ValueError("Search query cannot be empty")
+
+        # Issue #220: Validate max_results
+        if max_results < 0:
+            raise ValueError("max_results must be non-negative")
 
         results = index.search(
             query=query,
@@ -295,7 +311,14 @@ def create_mcp_server(
         Returns:
             Dictionary with 'elements' (list of elements with type, location, and
             optionally attributes/content) and 'count'.
+
+        Raises:
+            ValueError: If content_limit is negative.
         """
+        # Issue #220: Validate content_limit
+        if content_limit is not None and content_limit < 0:
+            raise ValueError("content_limit must be non-negative")
+
         elements = index.get_elements(
             element_type=element_type,
             section_path=section_path,

--- a/tests/test_mcp_negative_params_220.py
+++ b/tests/test_mcp_negative_params_220.py
@@ -1,0 +1,135 @@
+"""Tests for Issue #220: MCP tools should validate negative parameter values.
+
+Negative values for parameters like max_results, max_depth, level, and
+content_limit should be rejected with a clear error message.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from dacli.mcp_app import create_mcp_server
+
+
+@pytest.fixture
+def temp_doc_folder(tmp_path: Path) -> Path:
+    """Create a simple documentation folder for testing."""
+    doc_file = tmp_path / "test.md"
+    doc_file.write_text(
+        """# Test Document
+
+## Section 1
+
+Some content here.
+
+```python
+print("hello")
+```
+
+## Section 2
+
+More content.
+
+### Subsection 2.1
+
+Nested content.
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def mcp_server(temp_doc_folder: Path):
+    """Create an MCP server for testing."""
+    return create_mcp_server(temp_doc_folder)
+
+
+class TestSearchNegativeMaxResults:
+    """Test that search rejects negative max_results."""
+
+    def test_search_negative_max_results_should_error(self, mcp_server):
+        """Issue #220: search with negative max_results should raise error."""
+        # Get the search tool
+        search_tool = None
+        for tool in mcp_server._tool_manager._tools.values():
+            if tool.name == "search":
+                search_tool = tool
+                break
+
+        assert search_tool is not None, "search tool not found"
+
+        # Currently this does NOT raise an error - it should after fix
+        with pytest.raises(ValueError, match="max_results must be non-negative"):
+            search_tool.fn(query="test", max_results=-5)
+
+
+class TestGetStructureNegativeMaxDepth:
+    """Test that get_structure rejects negative max_depth."""
+
+    def test_get_structure_negative_max_depth_should_error(self, mcp_server):
+        """Issue #220: get_structure with negative max_depth should raise error."""
+        # Get the get_structure tool
+        get_structure_tool = None
+        for tool in mcp_server._tool_manager._tools.values():
+            if tool.name == "get_structure":
+                get_structure_tool = tool
+                break
+
+        assert get_structure_tool is not None, "get_structure tool not found"
+
+        # Currently this does NOT raise an error - it should after fix
+        with pytest.raises(ValueError, match="max_depth must be non-negative"):
+            get_structure_tool.fn(max_depth=-1)
+
+
+class TestGetSectionsAtLevelNegativeLevel:
+    """Test that get_sections_at_level rejects negative level."""
+
+    def test_get_sections_at_level_negative_should_error(self, mcp_server):
+        """Issue #220: get_sections_at_level with negative level should raise error."""
+        # Get the get_sections_at_level tool
+        get_sections_tool = None
+        for tool in mcp_server._tool_manager._tools.values():
+            if tool.name == "get_sections_at_level":
+                get_sections_tool = tool
+                break
+
+        assert get_sections_tool is not None, "get_sections_at_level tool not found"
+
+        # Currently this does NOT raise an error - it should after fix
+        with pytest.raises(ValueError, match="level must be positive"):
+            get_sections_tool.fn(level=-1)
+
+    def test_get_sections_at_level_zero_should_error(self, mcp_server):
+        """Issue #220: get_sections_at_level with level=0 should raise error."""
+        get_sections_tool = None
+        for tool in mcp_server._tool_manager._tools.values():
+            if tool.name == "get_sections_at_level":
+                get_sections_tool = tool
+                break
+
+        assert get_sections_tool is not None
+
+        # Level 0 doesn't make sense (levels are 1-based)
+        with pytest.raises(ValueError, match="level must be positive"):
+            get_sections_tool.fn(level=0)
+
+
+class TestGetElementsNegativeContentLimit:
+    """Test that get_elements rejects negative content_limit."""
+
+    def test_get_elements_negative_content_limit_should_error(self, mcp_server):
+        """Issue #220: get_elements with negative content_limit should raise error."""
+        # Get the get_elements tool
+        get_elements_tool = None
+        for tool in mcp_server._tool_manager._tools.values():
+            if tool.name == "get_elements":
+                get_elements_tool = tool
+                break
+
+        assert get_elements_tool is not None, "get_elements tool not found"
+
+        # Currently this does NOT raise an error - it should after fix
+        with pytest.raises(ValueError, match="content_limit must be non-negative"):
+            get_elements_tool.fn(include_content=True, content_limit=-10)

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.15"
+version = "0.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Added validation to reject negative values for MCP tool parameters
- Affected tools: `get_structure`, `get_sections_at_level`, `search`, `get_elements`
- Parameters now raise `ValueError` with clear message when negative values are provided

| Tool | Parameter | Validation |
|------|-----------|------------|
| `get_structure` | `max_depth` | must be >= 0 |
| `get_sections_at_level` | `level` | must be >= 1 |
| `search` | `max_results` | must be >= 0 |
| `get_elements` | `content_limit` | must be >= 0 |

## Test plan

- [x] Added `tests/test_mcp_negative_params_220.py` with 5 test cases
- [x] All 577 tests pass
- [x] Linting passes

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)