### PR TITLE
fix: CLI elements command warns on invalid element type (#225)

### DIFF
--- a/.vibe/development-plan-fix-cli-elements-invalid-type-warning-225.md
+++ b/.vibe/development-plan-fix-cli-elements-invalid-type-warning-225.md
@@ -1,0 +1,52 @@
+# Development Plan: asciidoc-mcp-new (fix/cli-elements-invalid-type-warning-225 branch)
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+*Define what you're building or fixing - this will be updated as requirements are gathered*
+## Key Decisions
+*Important decisions will be documented here as they are made*
+
+## Notes
+*Additional context and observations*
+
+## Reproduce
+### Tasks
+- [ ] *Tasks will be added as they are identified*
+
+### Completed
+- [x] Created development plan file
+
+## Analyze
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Fix
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Verify
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Finalize
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.16"
+version = "0.4.17"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.16"
+__version__ = "0.4.17"

--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -565,6 +565,12 @@ Examples:
 def elements(ctx: CliContext, section_path: str | None, element_type: str | None,
              recursive: bool, include_content: bool, content_limit: int | None):
     """Get elements (code blocks, tables, images) from documentation."""
+    # Issue #225: Validate element type and warn if invalid
+    valid_types = {"code", "table", "image", "plantuml", "admonition", "list"}
+    if element_type is not None and element_type not in valid_types:
+        valid_list = ", ".join(sorted(valid_types))
+        click.echo(f"Warning: Unknown element type '{element_type}'. Valid types are: {valid_list}")
+
     elems = ctx.index.get_elements(
         element_type=element_type,
         section_path=section_path,

--- a/tests/test_cli_elements_invalid_type_225.py
+++ b/tests/test_cli_elements_invalid_type_225.py
@@ -1,0 +1,91 @@
+"""Tests for Issue #225: CLI elements command warns on invalid element type.
+
+When an invalid --type is provided, the CLI should warn the user
+instead of silently returning count: 0.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dacli.cli import cli
+
+
+@pytest.fixture
+def temp_doc_with_elements(tmp_path: Path) -> Path:
+    """Create a Markdown file with various elements."""
+    doc_file = tmp_path / "test.md"
+    doc_file.write_text(
+        """# Test Document
+
+## Section 1
+
+Some content.
+
+```python
+print("hello")
+```
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+
+## Section 2
+
+More content.
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class TestElementsInvalidType:
+    """Test that invalid element type shows a warning."""
+
+    def test_invalid_type_shows_warning(self, temp_doc_with_elements: Path):
+        """Issue #225: Invalid element type should show warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(temp_doc_with_elements), "elements", "--type", "invalid_type"],
+        )
+
+        assert result.exit_code == 0
+        # Should warn about invalid type - look for the specific warning format
+        assert "Warning:" in result.output or "Unknown element type" in result.output
+        assert "invalid_type" in result.output
+        # Should suggest valid types
+        assert "code" in result.output
+
+    def test_valid_type_no_warning(self, temp_doc_with_elements: Path):
+        """Valid element type should not show a warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(temp_doc_with_elements), "elements", "--type", "code"],
+        )
+
+        assert result.exit_code == 0
+        # Should not have the specific warning message
+        assert "Warning:" not in result.output
+        assert "Unknown element type" not in result.output
+        # Should have found the code block
+        assert "count: 1" in result.output or '"count": 1' in result.output
+
+    def test_all_valid_types_accepted(self, temp_doc_with_elements: Path):
+        """All valid element types should be accepted without warning."""
+        runner = CliRunner()
+        valid_types = ["code", "table", "image", "plantuml", "admonition", "list"]
+
+        for element_type in valid_types:
+            result = runner.invoke(
+                cli,
+                ["--docs-root", str(temp_doc_with_elements), "elements", "--type", element_type],
+            )
+
+            assert result.exit_code == 0, f"Failed for type: {element_type}"
+            assert "Warning:" not in result.output, f"Unexpected warning for: {element_type}"
+            assert "Unknown element type" not in result.output, (
+                f"Unexpected unknown for: {element_type}"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.16"
+version = "0.4.17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- CLI `elements` command now shows a warning when an invalid `--type` is provided
- Warning message lists all valid element types: admonition, code, image, list, plantuml, table
- Previously, invalid types silently returned `count: 0` with no feedback

**Example:**
```
$ dacli elements --type invalid_type
Warning: Unknown element type 'invalid_type'. Valid types are: admonition, code, image, list, plantuml, table
elements:
count: 0
```

## Test plan

- [x] Added `tests/test_cli_elements_invalid_type_225.py` with 3 test cases
- [x] All 580 tests pass
- [x] Linting passes

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)