### PR TITLE
fix: CLI search command warns when scope doesn't exist (#226)

### DIFF
--- a/.vibe/development-plan-fix-cli-search-invalid-scope-warning-226.md
+++ b/.vibe/development-plan-fix-cli-search-invalid-scope-warning-226.md
@@ -1,0 +1,52 @@
+# Development Plan: asciidoc-mcp-new (fix/cli-search-invalid-scope-warning-226 branch)
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+*Define what you're building or fixing - this will be updated as requirements are gathered*
+## Key Decisions
+*Important decisions will be documented here as they are made*
+
+## Notes
+*Additional context and observations*
+
+## Reproduce
+### Tasks
+- [ ] *Tasks will be added as they are identified*
+
+### Completed
+- [x] Created development plan file
+
+## Analyze
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Fix
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Verify
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Finalize
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.17"
+version = "0.4.18"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"

--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -521,6 +521,17 @@ def search(ctx: CliContext, query: str, scope: str | None, max_results: int):
         click.echo("Error: Search query cannot be empty", err=True)
         sys.exit(EXIT_INVALID_ARGS)
 
+    # Issue #226: Warn if scope doesn't exist
+    if scope is not None:
+        # Check if scope exists as a section or document prefix
+        section = ctx.index.get_section(scope)
+        if section is None:
+            # Also check if it's a valid prefix for any section
+            all_sections = ctx.index.get_sections_at_level(0)  # Get all root sections
+            scope_exists = any(s.path.startswith(scope) for s in all_sections)
+            if not scope_exists:
+                click.echo(f"Warning: Scope '{scope}' not found in documentation structure.")
+
     results = ctx.index.search(
         query=query,
         scope=scope,

--- a/tests/test_cli_search_invalid_scope_226.py
+++ b/tests/test_cli_search_invalid_scope_226.py
@@ -1,0 +1,79 @@
+"""Tests for Issue #226: CLI search command warns on invalid scope.
+
+When a --scope that doesn't exist is provided, the CLI should warn the user
+instead of silently returning 0 results.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dacli.cli import cli
+
+
+@pytest.fixture
+def temp_doc_with_sections(tmp_path: Path) -> Path:
+    """Create a Markdown file with sections."""
+    doc_file = tmp_path / "test.md"
+    doc_file.write_text(
+        """# Test Document
+
+## Section 1
+
+Some content about testing.
+
+## Section 2
+
+More content here.
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class TestSearchInvalidScope:
+    """Test that invalid scope shows a warning."""
+
+    def test_invalid_scope_shows_warning(self, temp_doc_with_sections: Path):
+        """Issue #226: Invalid scope should show warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--docs-root", str(temp_doc_with_sections),
+                "search", "test", "--scope", "nonexistent-section"
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should warn about invalid scope
+        assert "Warning:" in result.output or "not found" in result.output.lower()
+        assert "nonexistent-section" in result.output
+
+    def test_valid_scope_no_warning(self, temp_doc_with_sections: Path):
+        """Valid scope should not show a warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--docs-root", str(temp_doc_with_sections),
+                "search", "test", "--scope", "test"
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should not have warning about scope not found
+        assert "Warning:" not in result.output
+        assert "not found" not in result.output.lower() or "total_results" in result.output
+
+    def test_no_scope_no_warning(self, temp_doc_with_sections: Path):
+        """Search without scope should not show a warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(temp_doc_with_sections), "search", "test"],
+        )
+
+        assert result.exit_code == 0
+        assert "Warning:" not in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.17"
+version = "0.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- CLI `search` command now shows a warning when a non-existent `--scope` is provided
- Previously, invalid scopes silently returned `total_results: 0` with no feedback

**Example:**
```
$ dacli search "test" --scope nonexistent-section
Warning: Scope 'nonexistent-section' not found in documentation structure.
query: test
results:
total_results: 0
```

## Test plan

- [x] Added `tests/test_cli_search_invalid_scope_226.py` with 3 test cases
- [x] All 583 tests pass
- [x] Linting passes

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)