### PR TITLE
fix: Empty files have valid line range (end_line >= line) (#224)

### DIFF
--- a/.vibe/development-plan-fix-empty-files-line-range-224.md
+++ b/.vibe/development-plan-fix-empty-files-line-range-224.md
@@ -1,0 +1,52 @@
+# Development Plan: asciidoc-mcp-new (fix/empty-files-line-range-224 branch)
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [bugfix](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/bugfix)*
+
+## Goal
+*Define what you're building or fixing - this will be updated as requirements are gathered*
+## Key Decisions
+*Important decisions will be documented here as they are made*
+
+## Notes
+*Additional context and observations*
+
+## Reproduce
+### Tasks
+- [ ] *Tasks will be added as they are identified*
+
+### Completed
+- [x] Created development plan file
+
+## Analyze
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Fix
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Verify
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+## Finalize
+### Tasks
+- [ ] *To be added when this phase becomes active*
+
+### Completed
+*None yet*
+
+
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.18"
+version = "0.4.19"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.18"
+__version__ = "0.4.19"

--- a/src/dacli/markdown_parser.py
+++ b/src/dacli/markdown_parser.py
@@ -488,7 +488,9 @@ class MarkdownStructureParser:
                 section.source_location.end_line = next_start - 1
             else:
                 # Last section ends at file end
-                section.source_location.end_line = total_lines
+                # Issue #224: Ensure end_line is at least equal to start line
+                # (handles empty files where total_lines could be 0)
+                section.source_location.end_line = max(total_lines, section.source_location.line)
 
     def _parse_elements(
         self,

--- a/tests/test_empty_files_line_range_224.py
+++ b/tests/test_empty_files_line_range_224.py
@@ -1,0 +1,87 @@
+"""Tests for Issue #224: Empty files should have valid line range.
+
+Empty files should either be skipped or have a valid line range (end_line >= line).
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dacli.cli import cli
+
+
+@pytest.fixture
+def temp_doc_with_empty_file(tmp_path: Path) -> Path:
+    """Create a folder with an empty file and a normal file."""
+    # Empty file
+    empty_file = tmp_path / "empty.md"
+    empty_file.write_text("", encoding="utf-8")
+
+    # Normal file with content
+    normal_file = tmp_path / "normal.md"
+    normal_file.write_text(
+        """# Normal Document
+
+Some content here.
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class TestEmptyFilesLineRange:
+    """Test that empty files have valid line ranges."""
+
+    def test_empty_file_valid_line_range(self, temp_doc_with_empty_file: Path):
+        """Issue #224: Empty files should have valid line range (end_line >= line)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(temp_doc_with_empty_file), "--format", "json", "structure"],
+        )
+
+        assert result.exit_code == 0
+
+        import json
+        data = json.loads(result.output)
+
+        # Find all sections and check line ranges
+        def check_line_ranges(sections):
+            for section in sections:
+                location = section.get("location", {})
+                line = location.get("line", 1)
+                end_line = location.get("end_line", 1)
+
+                # end_line should be >= line (valid range)
+                assert end_line >= line, (
+                    f"Invalid line range for '{section.get('path')}': "
+                    f"line={line}, end_line={end_line}"
+                )
+
+                # Check children recursively
+                if section.get("children"):
+                    check_line_ranges(section["children"])
+
+        check_line_ranges(data.get("sections", []))
+
+    def test_normal_file_line_range(self, temp_doc_with_empty_file: Path):
+        """Normal files should have proper line ranges."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--docs-root", str(temp_doc_with_empty_file), "--format", "json", "structure"],
+        )
+
+        assert result.exit_code == 0
+
+        import json
+        data = json.loads(result.output)
+
+        # Find the normal document
+        for section in data.get("sections", []):
+            if "normal" in section.get("path", "").lower():
+                location = section.get("location", {})
+                assert location.get("line", 0) >= 1
+                assert location.get("end_line", 0) >= 1
+                break

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -1830,8 +1830,9 @@ class TestEmptyMarkdownFileHandling:
         root = doc.sections[0]
         assert root.source_location.file == empty_file
         assert root.source_location.line == 1
-        # For empty files, end_line is 0 (no lines in file)
-        assert root.source_location.end_line == 0
+        # Issue #224: For empty files, end_line should be at least equal to line
+        # (valid line range where end_line >= line)
+        assert root.source_location.end_line == 1
 
     def test_whitespace_only_file_treated_as_empty(self, tmp_path):
         """File with only whitespace is treated as empty."""

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.18"
+version = "0.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Empty Markdown files previously had `end_line: 0` while `line: 1` (invalid range)
- Now empty files have `end_line: 1` (at least equal to start line)
- Ensures valid line range for tools processing structure output

**Before:**
```json
{"path": "empty", "location": {"line": 1, "end_line": 0}}
```

**After:**
```json
{"path": "empty", "location": {"line": 1, "end_line": 1}}
```

## Test plan

- [x] Added `tests/test_empty_files_line_range_224.py` with 2 test cases
- [x] Updated existing test expectation in `test_markdown_parser.py`
- [x] All 585 tests pass
- [x] Linting passes

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)