### PR TITLE
docs: Update documentation after bug triage fixes

### DIFF
--- a/.vibe/development-plan.md
+++ b/.vibe/development-plan.md
@@ -1,0 +1,74 @@
+# Development Plan: Dokumentation nach Bug-Fixes aktualisieren
+
+*Generated on 2026-01-31 by Vibe Feature MCP*
+*Workflow: [minor](https://mrsimpson.github.io/responsible-vibe-mcp/workflows/minor)*
+
+## Goal
+
+Dokumentation (Specs, User Manual) aktualisieren, um die Änderungen aus den letzten 12 geschlossenen Issues zu reflektieren:
+- Parameter-Validierung dokumentieren (#220)
+- CLI-Warnungen dokumentieren (#225, #226)
+- insert 'after' Verhalten klarstellen (#229)
+- Element-Typen vervollständigen
+
+## Key Decisions
+
+- **Workflow**: minor - Dokumentationsänderungen ohne Code-Änderungen
+- **Betroffene Dateien**:
+  - `src/docs/50-user-manual/20-mcp-tools.adoc`
+  - `src/docs/spec/02_api_specification.adoc`
+  - `src/docs/spec/06_cli_specification.adoc`
+  - `src/docs/spec/03_acceptance_criteria.adoc`
+
+## Notes
+
+Issues, die KEINE Dokumentationsänderungen erfordern: #218, #219, #216, #217, #223, #224, #227 (Implementation-Bugs oder Meta-Issues)
+
+## Explore
+
+### Phase Entrance Criteria
+- [x] Initiale Phase - keine Entrance Criteria
+
+### Tasks
+- [x] Issues analysieren und kategorisieren
+- [x] Betroffene Dokumentationsdateien identifizieren
+- [x] Konkrete Änderungen definieren
+
+### Completed
+- [x] Created development plan file
+- [x] 12 Issues analysiert
+- [x] 4 Dateien als betroffen identifiziert
+
+## Implement
+
+### Phase Entrance Criteria
+- [x] Alle betroffenen Dokumentationsdateien sind identifiziert
+- [x] Konkrete Änderungen sind definiert
+- [x] Keine offenen Fragen
+
+### Tasks
+*All completed*
+
+### Completed
+- [x] 20-mcp-tools.adoc: Parameter-Constraints und 'after' Klarstellung
+- [x] 02_api_specification.adoc: Parameter-Constraints und plantuml hinzufügen
+- [x] 06_cli_specification.adoc: Warnungen und 'after' Klarstellung
+- [x] 03_acceptance_criteria.adoc: Neue Szenarien hinzufügen
+
+## Finalize
+
+### Phase Entrance Criteria
+- [ ] Alle Dokumentationsänderungen sind umgesetzt
+- [ ] Keine Syntaxfehler in den Dateien
+
+### Tasks
+- [ ] Version bump (Patch)
+- [ ] Commit erstellen
+- [ ] PR erstellen
+
+### Completed
+*None yet*
+
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.20"
+version = "0.4.21"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -4,4 +4,4 @@ Enables LLM interaction with large AsciiDoc/Markdown documentation projects
 through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
-__version__ = "0.4.20"
+__version__ = "0.4.21"

--- a/src/docs/50-user-manual/20-mcp-tools.adoc
+++ b/src/docs/50-user-manual/20-mcp-tools.adoc
@@ -17,7 +17,7 @@ Get the hierarchical document structure.
 |===
 | Parameter | Type | Default | Description
 
-| `max_depth` | int \| null | null | Maximum depth to return. Use 1 for top-level only.
+| `max_depth` | int \| null | null | Maximum depth to return (must be >= 0). Use 1 for top-level only.
 |===
 
 .Returns
@@ -57,7 +57,7 @@ Get all sections at a specific nesting level.
 |===
 | Parameter | Type | Description
 
-| `level` | int | Nesting level (1 = chapters, 2 = sections, etc.)
+| `level` | int | Nesting level (must be >= 1). 1 = chapters, 2 = sections, etc.
 |===
 
 .Returns
@@ -171,7 +171,7 @@ Full-text search across documentation.
 
 | `query` | string | - | Search query (case-insensitive)
 | `scope` | string \| null | null | Path prefix to limit search scope
-| `max_results` | int | 50 | Maximum results to return
+| `max_results` | int | 50 | Maximum results to return (must be >= 0)
 |===
 
 .Returns
@@ -249,9 +249,9 @@ Insert content relative to a section.
 |===
 
 .Position Options
-- `before` - Insert before section start
-- `after` - Insert after section end
-- `append` - Append at end of section (before children)
+- `before` - Insert before section heading (adds blank line after content if needed)
+- `after` - Insert after section end, *including all child sections*
+- `append` - Append at end of section's own content (before children)
 
 .Returns
 [source,json]

--- a/src/docs/spec/02_api_specification.adoc
+++ b/src/docs/spec/02_api_specification.adoc
@@ -238,8 +238,8 @@ Retrieves the hierarchical document structure.
 |===
 | Parameter | Description
 
-| `max_depth` (int, optional)
-| Maximum depth of returned structure. Default: unlimited.
+| `max_depth` (int >= 0, optional)
+| Maximum depth of returned structure. Default: unlimited. Must be non-negative.
 |===
 
 **Response 200:**
@@ -329,8 +329,8 @@ Retrieves all sections at a specific level.
 |===
 | Parameter | Description
 
-| `level` (int, required)
-| Desired nesting depth (1 = chapter)
+| `level` (int >= 1, required)
+| Desired nesting depth. Must be positive (1 = chapter, 2 = section, etc.)
 |===
 
 **Response 200:**
@@ -365,7 +365,7 @@ Retrieves elements of a specific type.
 | Parameter | Description
 
 | `element_type` (string, optional)
-| Element type: `code`, `table`, `image`, `diagram`, `list`, `admonition`, `plantuml`. None returns all elements.
+| Element type: `code`, `table`, `image`, `plantuml`, `list`, `admonition`. None returns all elements. Invalid types return a warning (CLI) or error (MCP).
 
 | `section_path` (string, optional)
 | Restriction to specific section
@@ -437,8 +437,8 @@ Searches documentation content.
 | `scope` (string, optional)
 | Restriction to path prefix (e.g., "/architecture")
 
-| `max_results` (int, optional)
-| Maximum results to return (default: 20)
+| `max_results` (int >= 0, optional)
+| Maximum results to return (default: 20). Must be non-negative.
 |===
 
 **Response 200:**
@@ -548,7 +548,7 @@ Inserts content relative to a section.
 | Hierarchical path to reference section
 
 | `position` (string, required)
-| Where to insert: "before", "after", or "append"
+| Where to insert: "before" (adds blank line after content if next line is heading), "after" (inserts after section end *including all child sections*), or "append" (inserts at end of section's own content, before children)
 
 | `content` (string, required)
 | Content to insert

--- a/src/docs/spec/03_acceptance_criteria.adoc
+++ b/src/docs/spec/03_acceptance_criteria.adoc
@@ -48,6 +48,11 @@ Feature: Get document structure
     And "introduction" has no children
     And "constraints" has no children
 
+  Scenario: Reject negative max_depth (Issue #220)
+    When I call GET /structure?max_depth=-1
+    Then I receive HTTP Status 400
+    And the error message contains "must be non-negative"
+
   Scenario: Structure for empty project
     Given the project contains no documents
     When I call GET /structure
@@ -269,6 +274,11 @@ Feature: Search content
       }
       """
     Then the result list contains at most 5 matches
+
+  Scenario: CLI warns for non-existent scope (Issue #226)
+    When I call dacli search "query" --scope nonexistent.path
+    Then the CLI displays a warning about the scope not found
+    And the search continues (may return empty results)
 ----
 
 == Feature: Filter Elements by Type (UC-05)
@@ -316,6 +326,12 @@ Feature: Filter elements by type
     Then I receive HTTP Status 200
     And "count" is 0
     And "elements" is an empty array
+
+  Scenario: CLI warns for invalid element type (Issue #225)
+    When I call dacli elements --type charts
+    Then the CLI displays a warning about invalid type
+    And valid types are listed in the warning
+    And the result is empty (not an error)
 ----
 
 == Feature: Get Metadata (UC-06)
@@ -464,6 +480,19 @@ Feature: Insert content
       """
     Then I receive HTTP Status 200
     And the new content is after the section "introduction"
+
+  Scenario: Insert after includes all child sections (Issue #229)
+    Given the section "parent" has child sections "parent.child1" and "parent.child2"
+    When I call POST /section/parent/insert with:
+      """
+      {
+        "position": "after",
+        "content": "== New Section\n\nContent."
+      }
+      """
+    Then I receive HTTP Status 200
+    And the new content is after "parent.child2"
+    And the new content is before the next sibling of "parent"
 
   Scenario: Append content to section
     When I call POST /section/introduction/insert with:

--- a/src/docs/spec/06_cli_specification.adoc
+++ b/src/docs/spec/06_cli_specification.adoc
@@ -214,7 +214,7 @@ dacli search <QUERY> [--scope PATH] [--max-results N] [--limit N]
 **Options:**
 
 * `--max-results N`, `--limit N`: Maximum results to return (default: 20, aliases)
-* `--scope PATH`: Restrict search to path prefix
+* `--scope PATH`: Restrict search to path prefix. Warns if scope path doesn't exist in the documentation structure.
 
 **Example:**
 [source,bash]
@@ -244,7 +244,7 @@ dacli elements [SECTION_PATH] [--type TYPE] [--recursive] [--include-content] [-
 
 **Options:**
 
-* `--type TYPE`: Element type filter - `code`, `table`, `image`, `diagram`, `list`, `admonition`
+* `--type TYPE`: Element type filter - `code`, `table`, `image`, `plantuml`, `list`, `admonition`. Warns if type is invalid but still returns empty result.
 * `--recursive`: Include elements from child sections (default: exact match only)
 * `--include-content`: Include element content and attributes (Issue #159)
 * `--content-limit N`: Limit content to first N lines (requires `--include-content`)
@@ -390,9 +390,9 @@ dacli insert <PATH> --position before|after|append --content "..."
 
 **Position Options:**
 
-* `before` - Insert before the section heading
-* `after` - Insert after the section content (before next sibling)
-* `append` - Insert at end of section, after all subsections
+* `before` - Insert before the section heading. Adds blank line after content if next line is a heading.
+* `after` - Insert after the section end, *including all child sections* (before next sibling at same or higher level)
+* `append` - Insert at end of section's own content (before any child sections)
 
 **Content Input:**
 

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.20"
+version = "0.4.21"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Update specs and user manual to reflect changes from recent bug fixes (#220, #225, #226, #229, #232)
- Add parameter constraints documentation (>=0, >=1)
- Document CLI warnings for invalid element type and non-existent scope
- Clarify that insert 'after' position includes all child sections
- Add 'plantuml' to valid element types list
- Add new acceptance criteria scenarios

## Changes

| File | Change |
|------|--------|
| `20-mcp-tools.adoc` | Parameter constraints, 'after' clarification |
| `02_api_specification.adoc` | Parameter constraints, plantuml, 'after' clarification |
| `06_cli_specification.adoc` | CLI warnings, 'after' clarification |
| `03_acceptance_criteria.adoc` | 4 new Gherkin scenarios |

## Test plan

- [x] All 589 existing tests pass
- [x] No code changes, only documentation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)