### PR TITLE
Add comprehensive test report and GitHub issues for dacli-mcp

### DIFF
--- a/Test-Report.md
+++ b/Test-Report.md
@@ -1,0 +1,164 @@
+# dacli-mcp Test Report
+
+**Date:** 2026-01-31
+**Version Tested:** 0.4.20
+**Tester:** Automated test script + manual edge case testing
+
+## Executive Summary
+
+The dacli-mcp server was tested for functionality, edge cases, and error handling. **4 bugs** were identified, ranging from cosmetic to potentially document-corrupting issues.
+
+## Test Environment
+
+- **Platform:** Linux
+- **Python:** 3.12
+- **Test Documents:** Custom AsciiDoc and Markdown files with various edge cases (special characters, unicode, empty sections, deeply nested structures, HTML comments)
+
+## Test Categories
+
+### 1. Basic Functionality Tests
+
+All 9 MCP tools were tested for basic functionality:
+
+| Tool | Status | Notes |
+|------|--------|-------|
+| `get_structure` | PASS | max_depth validation works correctly |
+| `get_section` | PASS | Path resolution, error handling OK |
+| `get_sections_at_level` | PASS | Level validation works (1-based) |
+| `search` | PASS | Full-text search, query validation OK |
+| `get_elements` | PASS | Type filtering, recursive flag work |
+| `update_section` | PASS | Basic updates work, hash locking works |
+| `insert_content` | PASS | All positions work (before/after/append) |
+| `get_metadata` | PASS | Project and section metadata OK |
+| `validate_structure` | PASS | Detects broken includes |
+
+### 2. Input Validation Tests
+
+All negative parameter validation works correctly:
+
+- `get_structure(max_depth=-1)` raises ValueError
+- `get_sections_at_level(level=0)` raises ValueError
+- `get_sections_at_level(level=-1)` raises ValueError
+- `search(query="")` raises ValueError
+- `search(query="   ")` raises ValueError
+- `search(max_results=-1)` raises ValueError
+- `get_elements(content_limit=-1)` raises ValueError
+
+### 3. Edge Case Tests
+
+| Test Case | Status | Notes |
+|-----------|--------|-------|
+| Document with only title | PASS | Correctly returns empty content |
+| Document with emoji in path/title | PASS | Unicode handled correctly |
+| Empty sections | PASS | Returns minimal content |
+| Deeply nested paths (5 levels) | PASS | All levels accessible |
+| Unicode search (Umlauts) | PASS | Search finds unicode content |
+| Special characters in paths | PASS | Slugification works |
+| Non-existent paths | PASS | Returns PATH_NOT_FOUND with suggestions |
+| Leading slash in paths | PASS | Correctly normalized |
+
+### 4. Error Handling Tests
+
+| Test Case | Status | Notes |
+|-----------|--------|-------|
+| Non-existent section update | PASS | Returns error, not exception |
+| Invalid insert position | PASS | Returns descriptive error |
+| Wrong expected_hash | PASS | Hash conflict properly detected |
+| Broken include detection | PASS | validate_structure reports error |
+
+## Bugs Found
+
+### Bug 1: Markdown Document Level Inconsistency (Severity: Medium)
+
+**Description:** Markdown documents use level 1 for their root document, while AsciiDoc documents use level 0. This creates an inconsistency when working with mixed documentation projects.
+
+**Steps to Reproduce:**
+1. Create an AsciiDoc file with `= Title`
+2. Create a Markdown file with `# Title`
+3. Call `get_structure()`
+4. Observe: AsciiDoc root has `level: 0`, Markdown root has `level: 1`
+
+**Expected:** Both formats should use the same level for root documents.
+
+**Impact:** Makes it difficult to consistently query sections across mixed format projects using `get_sections_at_level`.
+
+---
+
+### Bug 2: Missing Blank Line After insert_content (Severity: Low)
+
+**Description:** When using `insert_content` with `position="after"`, the inserted content may not have a blank line before the next heading, which can cause rendering issues in AsciiDoc/Markdown.
+
+**Steps to Reproduce:**
+1. Insert content after a section that is followed by another heading
+2. The inserted content ends with a paragraph (not a heading)
+3. Observe: No blank line between inserted content and next heading
+
+**Expected:** A blank line should be inserted to maintain proper document structure.
+
+**Impact:** Cosmetic/rendering issue, may cause parsing problems in some renderers.
+
+---
+
+### Bug 3: update_section with Level Change Can Corrupt Hierarchy (Severity: High)
+
+**Description:** When using `update_section` with `preserve_title=False` and providing content with a different heading level, the document hierarchy can be corrupted.
+
+**Steps to Reproduce:**
+1. Get a level 2 section (e.g., `=== Goals`)
+2. Update it with `preserve_title=False` and level 1 content (`== New Title`)
+3. The section becomes level 1, potentially making sibling sections appear as children
+
+**Example:**
+```
+Before:
+== Introduction
+=== Goals          <- Level 2
+=== Non-Goals      <- Level 2 (sibling)
+
+After update_section("introduction.goals", "== New Title\n...", preserve_title=False):
+== Introduction
+== New Title       <- Now Level 1!
+=== Non-Goals      <- Appears as child of "New Title"
+```
+
+**Expected:** Either:
+- Warn/prevent level changes
+- Automatically adjust heading level to match original
+- Document this behavior clearly
+
+**Impact:** Can silently corrupt document structure.
+
+---
+
+### Bug 4: Markdown Headings with Inline HTML Comments Not Parsed (Severity: Medium)
+
+**Description:** Markdown headings that contain inline HTML comments are not recognized as headings by the parser.
+
+**Steps to Reproduce:**
+1. Create a Markdown file with: `## Heading <!-- comment -->`
+2. Call `get_structure()`
+3. The heading is not recognized; content is merged into previous section
+
+**Expected:** The heading should be recognized, with or without stripping the comment.
+
+**Impact:** Loss of document structure in Markdown files with inline HTML comments (common in documentation with notes).
+
+---
+
+## Test Coverage Summary
+
+| Category | Tests Run | Passed | Failed |
+|----------|-----------|--------|--------|
+| Basic Functionality | 50+ | 50+ | 0 |
+| Edge Cases | 15 | 15 | 0 |
+| Bug Discovery | 10+ | N/A | 4 bugs found |
+
+## Recommendations
+
+1. **High Priority:** Fix Bug 3 (level change corruption) - add validation or level adjustment
+2. **Medium Priority:** Fix Bug 1 (Markdown level consistency) and Bug 4 (HTML comments in headings)
+3. **Low Priority:** Fix Bug 2 (blank line handling) for cleaner output
+
+## Conclusion
+
+The dacli-mcp server is generally robust and handles most common use cases well. The validation for negative parameters is comprehensive. However, the identified bugs, particularly Bug 3, could cause data corruption in production use cases and should be addressed before wider deployment.

--- a/gh-issues.md
+++ b/gh-issues.md
@@ -1,0 +1,324 @@
+# GitHub Issues for dacli
+
+The following bugs were discovered during comprehensive testing of the dacli-mcp server.
+
+---
+
+## Issue 1: Markdown and AsciiDoc documents have inconsistent root levels
+
+### Title
+Markdown documents have level 1 root while AsciiDoc has level 0
+
+### Labels
+`bug`, `parser`, `markdown`
+
+### Description
+
+When mixing Markdown and AsciiDoc documents in the same project, the root document level is inconsistent:
+- AsciiDoc documents (`= Title`) have `level: 0`
+- Markdown documents (`# Title`) have `level: 1`
+
+This inconsistency makes it difficult to use `get_sections_at_level` consistently across mixed-format projects.
+
+### Steps to Reproduce
+
+1. Create test files:
+
+**test.adoc:**
+```asciidoc
+= AsciiDoc Document
+
+== Chapter
+Content
+```
+
+**test.md:**
+```markdown
+# Markdown Document
+
+## Chapter
+Content
+```
+
+2. Start the MCP server and call `get_structure()`
+
+3. Observe the levels:
+```json
+{
+  "sections": [
+    {"path": "test", "title": "AsciiDoc Document", "level": 0, ...},
+    {"path": "test_md", "title": "Markdown Document", "level": 1, ...}
+  ]
+}
+```
+
+### Expected Behavior
+
+Both document types should use the same level for their root document (preferably level 0 for consistency with AsciiDoc convention, since `=` in AsciiDoc and `#` in Markdown are semantically equivalent).
+
+### Actual Behavior
+
+AsciiDoc roots are level 0, Markdown roots are level 1.
+
+### Impact
+
+- `get_sections_at_level(level=1)` returns Markdown roots but AsciiDoc chapters
+- Makes cross-format queries inconsistent
+- Users cannot reliably get "all top-level documents" with a single call
+
+### Suggested Fix
+
+In the Markdown parser, adjust the level calculation so that `# Title` produces `level: 0` (matching AsciiDoc's `= Title`).
+
+---
+
+## Issue 2: insert_content "after" position missing blank line before next heading
+
+### Title
+insert_content with position="after" doesn't add blank line before following heading
+
+### Labels
+`bug`, `mcp-tools`, `low-priority`
+
+### Description
+
+When using `insert_content` with `position="after"`, if the content being inserted ends with a non-heading line and is followed by a heading in the document, no blank line is inserted between them. This violates AsciiDoc/Markdown conventions and may cause rendering issues.
+
+### Steps to Reproduce
+
+1. Create a test document:
+```asciidoc
+= Test
+
+== Chapter One
+Content
+
+== Chapter Two
+Content
+```
+
+2. Call:
+```python
+insert_content(
+    path="test:chapter-one",
+    position="after",
+    content="Inserted paragraph content.\n"
+)
+```
+
+3. Result:
+```asciidoc
+= Test
+
+== Chapter One
+Content
+
+Inserted paragraph content.
+== Chapter Two      <- No blank line before heading!
+Content
+```
+
+### Expected Behavior
+
+```asciidoc
+Inserted paragraph content.
+
+== Chapter Two      <- Blank line before heading
+```
+
+### Actual Behavior
+
+No blank line is added between the inserted content and the following heading.
+
+### Impact
+
+- May cause rendering issues in some parsers
+- Violates common AsciiDoc/Markdown conventions
+- Users need to manually add trailing newlines
+
+### Suggested Fix
+
+In `insert_content`, after inserting content with `position="after"`, check if the next line is a heading and insert a blank line if needed.
+
+---
+
+## Issue 3: update_section with preserve_title=False can corrupt document hierarchy
+
+### Title
+update_section allows level changes that corrupt document hierarchy
+
+### Labels
+`bug`, `mcp-tools`, `high-priority`, `data-corruption`
+
+### Description
+
+When using `update_section` with `preserve_title=False` and providing content with a different heading level than the original section, the document hierarchy can be silently corrupted. This is a data-integrity issue.
+
+### Steps to Reproduce
+
+1. Create a test document:
+```asciidoc
+= Document
+
+== Introduction
+
+=== Goals
+Original goals content
+
+=== Non-Goals
+Original non-goals content
+
+== Other Chapter
+```
+
+2. Call:
+```python
+update_section(
+    path="document:introduction.goals",
+    content="== Changed To Level 1\n\nNew content",
+    preserve_title=False
+)
+```
+
+3. Result - the document structure is corrupted:
+```asciidoc
+= Document
+
+== Introduction
+
+== Changed To Level 1    <- Was level 3 (===), now level 2 (==)
+New content
+
+=== Non-Goals            <- Now appears as CHILD of "Changed To Level 1"!
+Original non-goals content
+
+== Other Chapter
+```
+
+4. The structure index now shows:
+```
+document
+├── introduction
+├── changed-to-level-1
+│   └── non-goals        <- WRONG! Was sibling, now child
+└── other-chapter
+```
+
+### Expected Behavior
+
+One of the following:
+1. **Validation:** Raise an error if the new content has a different heading level
+2. **Auto-adjustment:** Automatically adjust the heading level to match the original
+3. **Warning:** Return a warning in the response about hierarchy changes
+
+### Actual Behavior
+
+The level change is silently applied, corrupting the document hierarchy.
+
+### Impact
+
+- **Data corruption:** Document structure is silently broken
+- **Lost context:** Sibling sections become children
+- **Difficult to detect:** No error or warning is raised
+
+### Suggested Fix
+
+Option A (Recommended): Validate heading level in new content and reject if different:
+```python
+if not preserve_title:
+    new_level = extract_heading_level(content)
+    if new_level != section.level:
+        return {"success": False, "error": "Content heading level mismatch"}
+```
+
+Option B: Auto-adjust the heading level:
+```python
+if not preserve_title:
+    content = adjust_heading_level(content, section.level)
+```
+
+---
+
+## Issue 4: Markdown headings with inline HTML comments are not recognized
+
+### Title
+Markdown parser fails to recognize headings containing inline HTML comments
+
+### Labels
+`bug`, `parser`, `markdown`
+
+### Description
+
+When a Markdown heading contains an inline HTML comment, the parser fails to recognize it as a heading. The heading content is instead merged into the previous section.
+
+### Steps to Reproduce
+
+1. Create a test Markdown file:
+```markdown
+# Document
+
+## Overview
+Content here.
+
+## Details
+More content.
+
+## Important <!-- TODO: review this section -->
+This section has an inline comment in its heading.
+```
+
+2. Call `get_structure()` or `get_section(path="document")`
+
+3. Observe that only "Overview" and "Details" are recognized as children:
+```json
+{
+  "path": "document",
+  "children": [
+    {"path": "document:overview", "title": "Overview"},
+    {"path": "document:details", "title": "Details"}
+  ]
+}
+```
+
+4. The "Important" section is completely missing; its content is merged into "Details"
+
+### Expected Behavior
+
+The heading should be recognized. The title could either:
+- Include the comment: `"Important <!-- TODO: review this section -->"`
+- Strip the comment: `"Important"`
+
+### Actual Behavior
+
+The heading is not recognized at all. Content is merged into the previous section.
+
+### Impact
+
+- **Lost structure:** Sections are not indexed
+- **Common pattern:** Inline HTML comments are frequently used in documentation for TODOs, notes, etc.
+- **Silent failure:** No error or warning is raised
+
+### Suggested Fix
+
+In the Markdown parser's heading regex or detection logic, handle inline HTML comments:
+
+```python
+# Current regex might be: r'^(#{1,6})\s+(.+)$'
+# Should handle: r'^(#{1,6})\s+(.+?)(?:\s*<!--.*-->)?$'
+```
+
+Or strip HTML comments before parsing:
+```python
+line = re.sub(r'<!--.*?-->', '', line)
+```
+
+---
+
+## Summary Table
+
+| Issue | Severity | Component | Status |
+|-------|----------|-----------|--------|
+| #1 Markdown level inconsistency | Medium | Parser | New |
+| #2 Missing blank line in insert | Low | MCP Tools | New |
+| #3 Level change hierarchy corruption | High | MCP Tools | New |
+| #4 HTML comments in Markdown headings | Medium | Parser | New |


### PR DESCRIPTION
## Summary

This PR adds comprehensive testing documentation for the dacli-mcp server, including a detailed test report and GitHub issues documenting bugs discovered during testing.

## Changes

- **Test-Report.md**: Comprehensive test report covering:
  - Executive summary of testing scope and findings
  - Test environment details (Linux, Python 3.12)
  - Test results for all 9 MCP tools (all passing basic functionality)
  - Input validation tests (all passing)
  - Edge case testing (15 tests, all passing)
  - 4 bugs identified with detailed reproduction steps and impact analysis
  - Test coverage summary and recommendations

- **gh-issues.md**: Formatted GitHub issues for the 4 bugs discovered:
  1. **Markdown/AsciiDoc level inconsistency** (Medium severity) - Root documents have different levels across formats
  2. **Missing blank line in insert_content** (Low severity) - No blank line added before following headings
  3. **Level change hierarchy corruption** (High severity) - `update_section` can silently corrupt document structure when heading levels change
  4. **HTML comments in Markdown headings** (Medium severity) - Headings with inline HTML comments are not recognized

## Notable Details

- Bug #3 is flagged as high priority due to potential data corruption risk
- All basic functionality tests passed (50+ tests)
- All input validation tests passed
- All edge case tests passed (15 tests)
- Issues are formatted with clear reproduction steps, expected vs actual behavior, and suggested fixes
- Recommendations prioritize fixing the data corruption issue before wider deployment

## Testing Scope

The testing covered:
- All 9 MCP tools (get_structure, get_section, get_sections_at_level, search, get_elements, update_section, insert_content, get_metadata, validate_structure)
- Parameter validation for negative/invalid inputs
- Edge cases (unicode, special characters, deeply nested structures, empty sections)
- Error handling and recovery
- Mixed format document handling

https://claude.ai/code/session_01Tt5AwYoUsqSHHXpka28JLJ