### PR TITLE
fix: report circular includes as errors instead of orphaned files (#251)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.26"
+version = "0.4.27"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -5,4 +5,4 @@ through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
 
-__version__ = "0.4.26"
+__version__ = "0.4.27"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.26"
+version = "0.4.27"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Detect circular include cycles in the AsciiDoc include graph during index building
- Report circular includes as `circular_include` errors in validation instead of misleading `orphaned_file` warnings
- Handles both mutual circular includes (A→B→A) and self-includes (A→A)

## Changes
- **`src/dacli/mcp_app.py`**: Added cycle detection using DFS in `_build_index()`. Also catches `CircularIncludeError` during parsing as fallback.
- **`src/dacli/services/validation_service.py`**: Reports stored circular include errors as `"circular_include"` type errors and excludes involved files from orphaned file detection.
- **`src/dacli/structure_index.py`**: Added `_circular_include_errors` list to store detected cycles.
- **`tests/test_circular_include_validation_251.py`**: 5 new tests covering mutual circular includes, self-includes, CLI output, and non-orphan assertion.

## Test plan
- [x] All 620 tests pass (615 existing + 5 new)
- [x] Circular includes (A↔B) reported as `circular_include` errors, not `orphaned_file` warnings
- [x] Self-includes (A→A) reported as `circular_include` errors
- [x] CLI `validate` command shows `circular_include` with exit code 4
- [x] No regressions in existing validation tests

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)