### PR TITLE
docs: ADR-010 - no Web UI, dacli is CLI and MCP only

### DIFF
--- a/src/docs/arc42/adr/ADR-010.adoc
+++ b/src/docs/arc42/adr/ADR-010.adoc
@@ -1,0 +1,33 @@
+=== ADR-010: No Web UI — dacli is CLI and MCP Only
+
+*Status:* Accepted (2026-02-07)
+
+*Context:*
+The original architecture documents (Quality Requirements, Concepts) assumed a Web UI component for dacli — specifically a document structure visualization (#12) and a real-time diff display (#13). Quality scenario USAB-3 described a "web UI" showing red/green diffs after modifications.
+
+However, dacli has evolved into a pure **CLI tool and MCP server** designed for LLM integration. The primary consumers are:
+
+* LLMs using dacli via MCP (Model Context Protocol)
+* LLMs using dacli via CLI/Bash tools
+* Developers using the CLI directly
+
+A Web UI would be a fundamentally different product — it requires frontend development (HTML/CSS/JS), serving static files, browser compatibility, and ongoing maintenance. This is outside dacli's core mission of providing structured, programmatic access to documentation.
+
+Tools like docToolchain already provide web-based documentation rendering. Adding a Web UI to dacli would duplicate that effort without clear benefit.
+
+*Decision:*
+dacli will **not include a Web UI**. The project scope is limited to CLI and MCP server interfaces. References to a Web UI in existing architecture documents will be removed.
+
+*Consequences:*
+
+_Positive:_
+
+* Clear, focused scope — CLI and MCP only
+* No frontend dependencies or maintenance burden
+* Simpler deployment (no static file serving, no browser compatibility)
+* Architecture documents accurately reflect the actual system
+
+_Negative:_
+
+* No visual diff display for documentation changes (LLMs and developers use the API/CLI output instead)
+* No interactive tree visualization (LLMs use `get_structure` programmatically)

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -17,7 +17,7 @@ This chapter describes concepts that are relevant across multiple parts of the a
 
 Security is addressed through standard, well-understood mechanisms.
 
-*   **Transport Security**: All communication with the server (API and Web UI) must be secured with HTTPS.
+*   **Transport Security**: All communication with the server (API and MCP) must be secured with HTTPS.
 *   **Execution Environment**: The server is assumed to run in a trusted, non-hostile environment. It has direct file system access, which is a powerful capability. Access to the server should be controlled by network rules.
 *   **Authentication/Authorization**: The PRD does not specify any multi-user or authentication requirements. The server is treated as a single-tenant system. If needed in the future, standard token-based authentication (e.g., API keys, OAuth2) could be added at the API gateway level or within FastAPI.
 

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -48,3 +48,7 @@ include::../adr/ADR-008.adoc[]
 ---
 
 include::../adr/ADR-009.adoc[]
+
+---
+
+include::../adr/ADR-010.adoc[]

--- a/src/docs/arc42/chapters/10_quality_requirements.adoc
+++ b/src/docs/arc42/chapters/10_quality_requirements.adoc
@@ -49,8 +49,9 @@ The system must be easy to use for its target audience of developers and archite
 | ID | Quality Goal | Scenario | Measurement
 | USAB-1 | MCP Compliance | A developer uses a standard MCP client to connect to the server and request the document structure. | The server responds with a valid structure as defined in the MCP specification, without requiring any custom client-side logic.
 | USAB-2 | Intuitiveness | A developer can successfully perform the top 5 use cases (e.g., get section, update section, search) by only reading the API documentation. | 90% success rate in user testing with the target audience.
-| USAB-3 | Feedback | When a section is modified via the web UI, the changes are immediately visible. | The UI displays a red/green diff of the changes within 1 second of the modification API call completing.
 |===
+
+NOTE: USAB-3 (Web UI diff display) was removed per ADR-010 — dacli has no Web UI.
 
 === Scalability
 


### PR DESCRIPTION
## Summary
- **ADR-010**: dacli will not include a Web UI — scope is CLI and MCP server only
- Removed USAB-3 quality scenario (Web UI diff display) from `10_quality_requirements.adoc`
- Updated transport security reference in `08_concepts.adoc` (Web UI → MCP)

## Context
Issues #12 (Structure Visualization) and #13 (Real-time Diff Display) proposed Web UI features. dacli has evolved into a pure CLI/MCP tool for LLM integration. A Web UI would be a fundamentally different product with frontend maintenance burden and no clear benefit — LLMs use the API programmatically, and tools like docToolchain already provide web rendering.

Closes #12
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)