### PR TITLE
feat: implement get_dependencies MCP tool (include_tree)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.28"
+version = "0.4.29"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -5,4 +5,4 @@ through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
 
-__version__ = "0.4.28"
+__version__ = "0.4.29"

--- a/src/dacli/mcp_app.py
+++ b/src/dacli/mcp_app.py
@@ -603,6 +603,19 @@ def create_mcp_server(
             return get_section_metadata(index, path)
 
     @mcp.tool()
+    def get_dependencies() -> dict:
+        """Get include dependencies between documentation files.
+
+        Use this tool to understand which files include other files.
+        Returns an include tree showing the relationships.
+
+        Returns:
+            'include_tree': Mapping of source file to list of included files.
+            'cross_references': Reserved for future use (currently empty).
+        """
+        return index.get_dependencies()
+
+    @mcp.tool()
     def validate_structure() -> dict:
         """Validate the document structure.
 

--- a/src/docs/50-user-manual/20-mcp-tools.adoc
+++ b/src/docs/50-user-manual/20-mcp-tools.adoc
@@ -4,7 +4,7 @@
 
 == Overview
 
-dacli provides 9 MCP tools for interacting with documentation projects via the Model Context Protocol. These tools enable LLMs to navigate, read, search, and modify documentation.
+dacli provides 10 MCP tools for interacting with documentation projects via the Model Context Protocol. These tools enable LLMs to navigate, read, search, and modify documentation.
 
 == Navigation Tools
 
@@ -306,6 +306,29 @@ Get project or section metadata.
   "subsection_count": 5
 }
 ----
+
+=== get_dependencies
+
+Get include dependencies between documentation files.
+
+.Parameters
+None
+
+.Returns
+[source,json]
+----
+{
+  "include_tree": {
+    "arc42.adoc": [
+      "chapters/01_introduction.adoc",
+      "chapters/02_constraints.adoc"
+    ]
+  },
+  "cross_references": []
+}
+----
+
+NOTE: `cross_references` is reserved for future use and currently returns an empty list.
 
 === validate_structure
 

--- a/src/docs/spec/02_api_specification.adoc
+++ b/src/docs/spec/02_api_specification.adoc
@@ -639,16 +639,27 @@ Retrieves metadata about the project or a specific section.
 
 '''
 
-==== get_dependencies (planned)
+==== get_dependencies
 
-[NOTE]
-====
-This tool is planned but not yet implemented.
-====
-
-Retrieves include dependencies and cross-references.
+Retrieves include dependencies between documentation files.
 
 **Use Case:** UC-06 (Extension)
+
+**Response 200:**
+[source,json]
+----
+{
+  "include_tree": {
+    "arc42.adoc": [
+      "chapters/01_introduction.adoc",
+      "chapters/02_constraints.adoc"
+    ]
+  },
+  "cross_references": []
+}
+----
+
+NOTE: `cross_references` is reserved for future use and currently returns an empty list.
 
 '''
 
@@ -749,6 +760,7 @@ Error responses are returned as dictionaries with an `error` key:
 | `validate_structure` | Validate document structure
 | `update_section` | Update section content
 | `insert_content` | Insert content before/after sections
+| `get_dependencies` | Get include dependencies
 |===
 
 .Planned Tools
@@ -757,7 +769,6 @@ Error responses are returned as dictionaries with an `error` key:
 | Tool | Description
 
 | `update_element` | Replace a specific element (code, table)
-| `get_dependencies` | Get include dependencies
 | `get_health` | Server health status
 | `reindex` | Trigger manual reindexing
 |===

--- a/tests/test_get_dependencies_67.py
+++ b/tests/test_get_dependencies_67.py
@@ -1,0 +1,240 @@
+"""Tests for get_dependencies endpoint (Issue #67, Phase 1: include_tree)."""
+
+from pathlib import Path
+
+from dacli.asciidoc_parser import AsciidocDocument, AsciidocStructureParser, IncludeInfo
+from dacli.models import Document, SourceLocation
+from dacli.structure_index import StructureIndex
+
+
+class TestGetDependenciesStructureIndex:
+    """Tests for StructureIndex.get_dependencies() method."""
+
+    def test_empty_index_returns_empty_tree(self):
+        """get_dependencies on empty index returns empty include_tree."""
+        index = StructureIndex()
+        index.build_from_documents([])
+        result = index.get_dependencies()
+        assert result == {"include_tree": {}, "cross_references": []}
+
+    def test_asciidoc_doc_with_includes(self, tmp_path):
+        """Include tree is built from AsciidocDocument.includes."""
+        doc = AsciidocDocument(
+            file_path=tmp_path / "main.adoc",
+            title="Main",
+            sections=[],
+            elements=[],
+            includes=[
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=tmp_path / "main.adoc", line=5
+                    ),
+                    target_path=tmp_path / "chapters" / "intro.adoc",
+                ),
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=tmp_path / "main.adoc", line=10
+                    ),
+                    target_path=tmp_path / "chapters" / "setup.adoc",
+                ),
+            ],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+
+        assert "include_tree" in result
+        tree = result["include_tree"]
+        assert "main.adoc" in tree
+        assert set(tree["main.adoc"]) == {
+            "chapters/intro.adoc",
+            "chapters/setup.adoc",
+        }
+
+    def test_markdown_doc_has_no_includes(self, tmp_path):
+        """Markdown documents don't contribute to include_tree."""
+        doc = Document(
+            file_path=tmp_path / "readme.md",
+            title="Readme",
+            sections=[],
+            elements=[],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+        assert result["include_tree"] == {}
+
+    def test_multiple_docs_with_includes(self, tmp_path):
+        """Multiple AsciiDoc documents each contribute their includes."""
+        doc1 = AsciidocDocument(
+            file_path=tmp_path / "arc42.adoc",
+            title="Arc42",
+            sections=[],
+            elements=[],
+            includes=[
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=tmp_path / "arc42.adoc", line=3
+                    ),
+                    target_path=tmp_path / "chapters" / "01_intro.adoc",
+                ),
+            ],
+        )
+        doc2 = AsciidocDocument(
+            file_path=tmp_path / "manual.adoc",
+            title="Manual",
+            sections=[],
+            elements=[],
+            includes=[
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=tmp_path / "manual.adoc", line=2
+                    ),
+                    target_path=tmp_path / "installation.adoc",
+                ),
+            ],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc1, doc2])
+        result = index.get_dependencies()
+        tree = result["include_tree"]
+
+        assert len(tree) == 2
+        assert "arc42.adoc" in tree
+        assert "manual.adoc" in tree
+
+    def test_asciidoc_doc_without_includes(self, tmp_path):
+        """AsciiDoc document with no includes has empty entry or is absent."""
+        doc = AsciidocDocument(
+            file_path=tmp_path / "simple.adoc",
+            title="Simple",
+            sections=[],
+            elements=[],
+            includes=[],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+        # Documents with no includes should not appear in the tree
+        assert result["include_tree"] == {}
+
+    def test_cross_references_placeholder(self, tmp_path):
+        """Phase 1: cross_references is always an empty list."""
+        doc = AsciidocDocument(
+            file_path=tmp_path / "main.adoc",
+            title="Main",
+            sections=[],
+            elements=[],
+            includes=[
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=tmp_path / "main.adoc", line=1
+                    ),
+                    target_path=tmp_path / "other.adoc",
+                ),
+            ],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+        assert result["cross_references"] == []
+
+    def test_paths_are_relative_to_docs_root(self, tmp_path):
+        """Paths in include_tree should be relative to docs_root (file_path parent)."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        doc = AsciidocDocument(
+            file_path=docs / "main.adoc",
+            title="Main",
+            sections=[],
+            elements=[],
+            includes=[
+                IncludeInfo(
+                    source_location=SourceLocation(
+                        file=docs / "main.adoc", line=1
+                    ),
+                    target_path=docs / "sub" / "chapter.adoc",
+                ),
+            ],
+        )
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+        tree = result["include_tree"]
+        # Keys and values should be relative paths (strings, not absolute)
+        for key in tree:
+            assert not Path(key).is_absolute()
+            for val in tree[key]:
+                assert not Path(val).is_absolute()
+
+
+class TestGetDependenciesMCPTool:
+    """Tests for get_dependencies MCP tool."""
+
+    def test_get_dependencies_tool_exists(self, tmp_path):
+        """get_dependencies is registered as an MCP tool."""
+        from dacli.mcp_app import create_mcp_server
+
+        mcp = create_mcp_server(tmp_path)
+        tool_names = [t.name for t in mcp._tool_manager._tools.values()]
+        assert "get_dependencies" in tool_names
+
+    def test_get_dependencies_tool_returns_structure(self, tmp_path):
+        """get_dependencies MCP tool returns include_tree and cross_references."""
+        # Create a simple AsciiDoc project with includes
+        main = tmp_path / "main.adoc"
+        chapter = tmp_path / "chapters" / "intro.adoc"
+        chapter.parent.mkdir(parents=True)
+        main.write_text("= Main\n\ninclude::chapters/intro.adoc[]\n")
+        chapter.write_text("== Introduction\n\nSome content.\n")
+
+        # Parse and build index to test the service method directly
+        # (MCP tool is just a thin wrapper around index.get_dependencies())
+        parser = AsciidocStructureParser(base_path=tmp_path)
+        doc = parser.parse_file(main)
+
+        index = StructureIndex()
+        index.build_from_documents([doc])
+        result = index.get_dependencies()
+
+        assert "include_tree" in result
+        assert "cross_references" in result
+        assert isinstance(result["include_tree"], dict)
+        assert isinstance(result["cross_references"], list)
+
+
+class TestGetDependenciesIntegration:
+    """Integration test with real AsciiDoc parsing."""
+
+    def test_parsed_doc_includes_are_in_tree(self, tmp_path):
+        """End-to-end: parse AsciiDoc with includes, check include_tree."""
+        # Create files
+        main = tmp_path / "main.adoc"
+        ch1 = tmp_path / "chapters" / "ch1.adoc"
+        ch2 = tmp_path / "chapters" / "ch2.adoc"
+        ch1.parent.mkdir(parents=True)
+
+        main.write_text(
+            "= Main Document\n\n"
+            "include::chapters/ch1.adoc[]\n\n"
+            "include::chapters/ch2.adoc[]\n"
+        )
+        ch1.write_text("== Chapter 1\n\nContent of chapter 1.\n")
+        ch2.write_text("== Chapter 2\n\nContent of chapter 2.\n")
+
+        # Parse
+        parser = AsciidocStructureParser(base_path=tmp_path)
+        doc = parser.parse_file(main)
+
+        # Build index
+        index = StructureIndex()
+        index.build_from_documents([doc])
+
+        result = index.get_dependencies()
+        tree = result["include_tree"]
+
+        assert "main.adoc" in tree
+        targets = tree["main.adoc"]
+        assert len(targets) == 2
+        assert "chapters/ch1.adoc" in targets
+        assert "chapters/ch2.adoc" in targets

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.28"
+version = "0.4.29"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Adds `get_dependencies` MCP tool that returns the include tree (which AsciiDoc files include which other files)
- Adds `get_dependencies()` method to `StructureIndex` that extracts include relationships from parsed `AsciidocDocument.includes`
- Phase 1 of #67: `cross_references` is reserved for future use (returns empty list)
- Updates API spec and user manual documentation
- 10 new tests (unit, MCP tool, integration with real parsing)
- Bumps version to 0.4.29

Fixes #67

## Test plan
- [x] 10 new tests covering empty index, single/multiple docs, Markdown exclusion, relative paths, integration
- [x] All 690 tests pass (no regressions)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)