### PR TITLE
fix: add blockquote to CLI valid_types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.30"
+version = "0.4.31"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -5,4 +5,4 @@ through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
 
-__version__ = "0.4.30"
+__version__ = "0.4.31"

--- a/src/dacli/cli.py
+++ b/src/dacli/cli.py
@@ -621,7 +621,7 @@ def elements(ctx: CliContext, section_path: str | None, element_type: str | None
              recursive: bool, include_content: bool, content_limit: int | None):
     """Get elements (code blocks, tables, images) from documentation."""
     # Issue #225: Validate element type and warn if invalid
-    valid_types = {"code", "table", "image", "plantuml", "admonition", "list"}
+    valid_types = {"code", "table", "image", "plantuml", "admonition", "list", "blockquote"}
     if element_type is not None and element_type not in valid_types:
         valid_list = ", ".join(sorted(valid_types))
         click.echo(f"Warning: Unknown element type '{element_type}'. Valid types are: {valid_list}")

--- a/tests/test_blockquote_type_270.py
+++ b/tests/test_blockquote_type_270.py
@@ -1,0 +1,64 @@
+"""Tests for blockquote element type consistency (Issue #270).
+
+blockquote is listed in --help but rejected at runtime by valid_types check.
+"""
+
+from click.testing import CliRunner
+
+from dacli.cli import cli
+
+
+class TestBlockquoteElementType:
+    """blockquote must be accepted as a valid element type."""
+
+    def test_blockquote_no_warning(self, tmp_path):
+        """Passing --type blockquote must not produce an 'Unknown element type' warning."""
+        doc = tmp_path / "test.md"
+        doc.write_text("# Test\n\n> A blockquote\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--docs-root", str(tmp_path),
+            "--format", "json",
+            "elements",
+            "--type", "blockquote",
+        ])
+
+        assert "Unknown element type" not in result.output, (
+            f"blockquote rejected as unknown: {result.output}"
+        )
+
+    def test_valid_types_match_help_text(self):
+        """All types listed in --help must be in valid_types."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["elements", "--help"])
+
+        # Extract types from help text
+        # Help says: "Element type: admonition, blockquote, code, image, list, plantuml, table"
+        assert "blockquote" in result.output, "blockquote missing from --help"
+
+    def test_all_model_element_types_accepted(self, tmp_path):
+        """Every ElementType in the model should be accepted by CLI validation."""
+        from dacli.models import Element
+
+        doc = tmp_path / "test.md"
+        doc.write_text("# Test\n\nSome content.\n")
+
+        runner = CliRunner()
+        # Get all valid types from the Element model's type field
+        # The Literal type annotation lists all valid values
+        import typing
+        type_hints = typing.get_type_hints(Element)
+        # Element.type is Literal["code", "table", ...]
+        literal_args = typing.get_args(type_hints["type"])
+
+        for etype in literal_args:
+            result = runner.invoke(cli, [
+                "--docs-root", str(tmp_path),
+                "--format", "json",
+                "elements",
+                "--type", etype,
+            ])
+            assert "Unknown element type" not in result.output, (
+                f"Element type '{etype}' rejected by CLI but defined in model"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.30"
+version = "0.4.31"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add `blockquote` to `valid_types` set in CLI `elements` command so it's no longer rejected at runtime
- The type was already listed in `--help` text and defined in `models.py`, but missing from the validation set

Fixes #270

## Test plan
- [x] 3 new tests in `test_blockquote_type_270.py`
- [x] All 702 tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)