### PR TITLE
docs: add C4 diagram rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,5 +222,17 @@ Located in `src/docs/arc42/chapters/09_architecture_decisions.adoc`:
 | `update_section` | Update section content (with optimistic locking) |
 | `insert_content` | Insert content before/after sections |
 
+| `get_dependencies` | Get include tree for AsciiDoc documents |
+
 For detailed tool documentation, see `src/docs/50-user-manual/`.
+
+## C4 Diagram Quality Rules
+
+When creating or modifying C4 diagrams in arc42 docs:
+- File systems, databases are `ContainerDb` inside system boundary, NOT `System_Ext`
+- Component diagrams show internals of ONE container — keep consistent across diagrams
+- You can NOT zoom into components, only into containers
+- Use `LAYOUT_WITH_LEGEND()` consistently on all diagrams
+- Write abstraction type in Container_Boundary labels (e.g. `"MCP Server [Container: Python, FastMCP]"`)
+- Review checklist: https://c4model.com/review
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dacli"
-version = "0.4.34"
+version = "0.4.35"
 description = "Documentation Access CLI - Navigate and query large documentation projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dacli/__init__.py
+++ b/src/dacli/__init__.py
@@ -5,4 +5,4 @@ through hierarchical, content-aware access via the Model Context Protocol (MCP).
 """
 
 
-__version__ = "0.4.34"
+__version__ = "0.4.35"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "dacli"
-version = "0.4.34"
+version = "0.4.35"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add C4 diagram quality rules to CLAUDE.md, learned from Simon Brown's review of our Building Block View diagrams
- Add missing `get_dependencies` tool to MCP tools table

These rules ensure future AI sessions apply C4 conventions proactively when generating diagrams, rather than only recognizing mistakes after review.

## Test plan
- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)