### PR TITLE
feat: add AsciiDoc linter pre-commit hook (#285)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,13 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: mixed-line-ending
+
+  # AsciiDoc linter (local hook - requires dev dependencies)
+  - repo: local
+    hooks:
+      - id: asciidoc-linter
+        name: AsciiDoc Linter
+        entry: uv run asciidoc-linter
+        language: system
+        files: \.(adoc|asciidoc)$
+        args: [--format, plain]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,40 @@ Development happens on a fork to keep `upstream/main` stable for `uv tool instal
 - Documentation, Issues, Pull-Requests etc. is always written in english
 - use responsible-vibe-mcp wherever suitable
 
+### AsciiDoc Linting
+
+The project uses [asciidoc-linter](https://github.com/docToolchain/asciidoc-linter) as a pre-commit hook to catch AsciiDoc syntax errors.
+
+**Known Issues (as of 2026-02-11):**
+
+- **WS001 false positives**: Linter incorrectly flags `*bold*` and `**bold**` syntax as list markers needing spaces
+  - These warnings can be safely ignored - the syntax is correct AsciiDoc
+  - See [asciidoc-linter#41](https://github.com/docToolchain/asciidoc-linter/issues/41)
+  - All ADR files (ADR-001 through ADR-013) trigger these false positives
+
+- **Markdown tables NOT detected**: Linter does not catch Markdown table syntax (`|---|---|`) in AsciiDoc files
+  - See [asciidoc-linter#38](https://github.com/docToolchain/asciidoc-linter/issues/38)
+  - Manual review required for table syntax
+
+**Workaround for commits:**
+
+When committing changes to `.adoc` files, the pre-commit hook may fail due to WS001 false positives:
+
+```bash
+# If only false positives (verify manually):
+git commit --no-verify -m "your message"
+
+# Or fix the linter output and commit normally
+git commit -m "your message"
+```
+
+**Real errors to watch for:**
+- Incorrect table syntax (Markdown vs AsciiDoc)
+- Heading hierarchy issues (HEAD001-003)
+- Unterminated blocks (BLOCK001)
+
+The linter runs on **all `.adoc` and `.asciidoc` files** in the repository.
+
 ## Commands
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ Issues = "https://github.com/docToolchain/dacli/issues"
 
 [project.optional-dependencies]
 dev = [
+    "asciidoc-linter @ git+https://github.com/docToolchain/asciidoc-linter.git",
     "hypothesis>=6.0.0",
     "pre-commit>=4.0.0",
     "pytest>=8.0.0",
@@ -54,6 +55,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dacli"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/docs/arc42/adr/ADR-011.adoc
+++ b/src/docs/arc42/adr/ADR-011.adoc
@@ -8,13 +8,16 @@
 
 The dacli CLI module requires risk classification according to the Risk Radar framework to determine appropriate security and quality assurance measures. The assessment evaluates five dimensions:
 
-| Dimension | Score | Level | Evidence |
-|-----------|-------|-------|----------|
-| Code Type | 2 | Business Logic | Click commands, service layer orchestration (`src/dacli/cli.py`, `src/dacli/services/`) |
-| Language | 2 | Dynamically typed | Python 3.12+ — 100% `.py` files |
-| Deployment | 1 | Internal tool | Command-line tool for documentation teams |
-| Data Sensitivity | 1 | Internal business data | Operates on internal documentation |
-| Blast Radius | 2 | Data loss (recoverable) | Could corrupt docs, recoverable from git |
+[cols="2,1,2,5"]
+|===
+| Dimension | Score | Level | Evidence
+
+| Code Type | 2 | Business Logic | Click commands, service layer orchestration (`src/dacli/cli.py`, `src/dacli/services/`)
+| Language | 2 | Dynamically typed | Python 3.12+ — 100% `.py` files
+| Deployment | 1 | Internal tool | Command-line tool for documentation teams
+| Data Sensitivity | 1 | Internal business data | Operates on internal documentation
+| Blast Radius | 2 | Data loss (recoverable) | Could corrupt docs, recoverable from git
+|===
 
 *Decision:*
 

--- a/src/docs/arc42/adr/ADR-012.adoc
+++ b/src/docs/arc42/adr/ADR-012.adoc
@@ -8,13 +8,16 @@
 
 The dacli-mcp MCP server module requires risk classification according to the Risk Radar framework to determine appropriate security and quality assurance measures. The assessment evaluates five dimensions:
 
-| Dimension | Score | Level | Evidence |
-|-----------|-------|-------|----------|
-| Code Type | 2 | Business Logic | MCP tools, service layer (`src/dacli/mcp_app.py`, `src/dacli/services/`) |
-| Language | 2 | Dynamically typed | Python 3.12+ — 100% `.py` files |
-| Deployment | 1 | Internal tool | MCP server for LLM integration in internal workflows |
-| Data Sensitivity | 1 | Internal business data | Operates on internal documentation |
-| Blast Radius | 2 | Data loss (recoverable) | Could corrupt docs, recoverable from git |
+[cols="2,1,2,5"]
+|===
+| Dimension | Score | Level | Evidence
+
+| Code Type | 2 | Business Logic | MCP tools, service layer (`src/dacli/mcp_app.py`, `src/dacli/services/`)
+| Language | 2 | Dynamically typed | Python 3.12+ — 100% `.py` files
+| Deployment | 1 | Internal tool | MCP server for LLM integration in internal workflows
+| Data Sensitivity | 1 | Internal business data | Operates on internal documentation
+| Blast Radius | 2 | Data loss (recoverable) | Could corrupt docs, recoverable from git
+|===
 
 **Note:** Initial consideration was given to Code Type score 3 (API/Database Queries) since the module exposes API endpoints (MCP tools). However, user confirmed score 2 as these are internal service APIs without public exposure or direct database access.
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,14 @@ wheels = [
 ]
 
 [[package]]
+name = "asciidoc-linter"
+version = "0.1.0"
+source = { git = "https://github.com/docToolchain/asciidoc-linter.git#cf450fe070ad60979440b3819ddaec927a8c4ce8" }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +401,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "asciidoc-linter" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -404,6 +413,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asciidoc-linter", marker = "extra == 'dev'", git = "https://github.com/docToolchain/asciidoc-linter.git" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.115.0" },


### PR DESCRIPTION
## Summary

Adds [asciidoc-linter](https://github.com/docToolchain/asciidoc-linter) as a pre-commit hook to catch AsciiDoc syntax errors before commit. This addresses issue #285.

## Changes

### 1. AsciiDoc Linter Integration

**Added:**
- `asciidoc-linter` as dev dependency (installed from GitHub, not yet on PyPI)
- Local pre-commit hook in `.pre-commit-config.yaml`
- `tool.hatch.metadata.allow-direct-references = true` to support git dependencies

**Runs on:** All `.adoc` and `.asciidoc` files in the repository

### 2. Fixed Markdown Tables in ADRs

Converted incorrect Markdown table syntax to proper AsciiDoc format:

**Before (Markdown):**
```markdown
| Dimension | Score | Level | Evidence |
|-----------|-------|-------|----------|
| Code Type | 2 | Business Logic | ... |
```

**After (AsciiDoc):**
```asciidoc
[cols="2,1,2,5"]
|===
| Dimension | Score | Level | Evidence

| Code Type | 2 | Business Logic | ...
|===
```

**Files fixed:**
- `src/docs/arc42/adr/ADR-011.adoc`
- `src/docs/arc42/adr/ADR-012.adoc`

### 3. Documentation

Updated `CLAUDE.md` with:
- AsciiDoc linter setup instructions
- Known issues (WS001 false positives, Markdown table detection missing)
- Workaround guide for commits blocked by false positives
- Explanation of when to use `--no-verify`

## Known Limitations

### Linter Issues (reported upstream)

1. **WS001 false positives** ([asciidoc-linter#41](https://github.com/docToolchain/asciidoc-linter/issues/41))
   - Incorrectly flags `*bold*` syntax as list markers
   - All ADR files trigger these warnings
   - Workaround: Use `git commit --no-verify` when only false positives present

2. **Markdown tables NOT detected** ([asciidoc-linter#38](https://github.com/docToolchain/asciidoc-linter/issues/38))
   - Current linter does not catch `|---|---|` syntax
   - Manual review still required for table syntax
   - Feature request filed upstream

### Feature Requests Filed

Also filed upstream enhancement requests:
- [asciidoc-linter#39](https://github.com/docToolchain/asciidoc-linter/issues/39): Native pre-commit hooks support (`.pre-commit-hooks.yaml`)
- [asciidoc-linter#40](https://github.com/docToolchain/asciidoc-linter/issues/40): Publish to PyPI for easier installation

## Testing

**Linter verification:**
```bash
# Test on ADR with known Markdown table (manually found)
uv run asciidoc-linter src/docs/arc42/adr/ADR-011.adoc

# Run pre-commit hook manually
uv run pre-commit run asciidoc-linter --all-files
```

**Results:**
- ✅ Pre-commit hook executes successfully
- ✅ Detects WS001 issues (false positives on `*bold*`)
- ❌ Does NOT detect Markdown tables (expected - issue #38)

## Migration Guide

For contributors:

1. Install dev dependencies:
   ```bash
   uv sync --extra dev
   ```

2. Pre-commit hooks auto-install on first commit

3. If commit is blocked by WS001 false positives:
   - Review the warnings manually
   - If only false positives (verify `*bold*` syntax is correct):
     ```bash
     git commit --no-verify -m "your message"
     ```

4. Watch for real errors:
   - Incorrect table syntax (Markdown vs AsciiDoc)
   - Heading hierarchy issues
   - Unterminated blocks

## Breaking Changes

None

## Related Issues

- Closes #285 (Add AsciiDoc linter)
- Depends on upstream fixes:
  - [asciidoc-linter#38](https://github.com/docToolchain/asciidoc-linter/issues/38) - Markdown table detection
  - [asciidoc-linter#41](https://github.com/docToolchain/asciidoc-linter/issues/41) - WS001 false positives

---

**Generated with 🤖 Claude Code (AI-assisted development)**

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>